### PR TITLE
feat: update frontend UI with full SCADA panels, fault injection, and…

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -2,10 +2,12 @@ import React, { useState, useCallback, useMemo } from 'react';
 import { useMockTurbineData } from './hooks/useMockTurbineData';
 import { useRealtimeData } from './hooks/useRealtimeData';
 import { useMockMaintenanceData } from './hooks/useMockMaintenanceData';
+import { useI18n } from './hooks/useI18n';
 import { type TurbineData, TurbineStatus, DataSourceType, type WorkOrder, type Technician, WorkOrderStatus } from './types';
 import FarmOverview from './components/FarmOverview';
 import TurbineDetail from './components/TurbineDetail';
 import MaintenanceHub from './components/MaintenanceHub';
+import FaultInjectionPanel from './components/FaultInjectionPanel';
 import { HeaderIcon, WrenchScrewdriverIcon, ChartBarIcon, CogIcon } from './components/icons';
 import DispatchModal from './components/DispatchModal';
 import WorkOrderDetailModal from './components/WorkOrderDetailModal';
@@ -27,8 +29,9 @@ const NavButton = ({ isActive, onClick, children }: {isActive: boolean, onClick:
 
 const App: React.FC = () => {
   const { settings, saveSettings } = useSettings();
+  const { lang, setLang, ui } = useI18n();
 
-  // Use mock data for MOCK mode, real API data for OPC_DA / MODBUS_TCP
+  // Use mock data for MOCK mode, real API data for SIMULATION / OPC_DA
   const mockData = useMockTurbineData();
   const realtimeData = useRealtimeData();
 
@@ -38,7 +41,7 @@ const App: React.FC = () => {
   const { workOrders } = maintenance;
 
   const [selectedTurbine, setSelectedTurbine] = useState<TurbineData | null>(null);
-  const [view, setView] = useState<'dashboard' | 'maintenance' | 'settings'>('dashboard');
+  const [view, setView] = useState<'dashboard' | 'maintenance' | 'faults' | 'settings'>('dashboard');
 
   const [isDispatchModalOpen, setIsDispatchModalOpen] = useState(false);
   const [turbineToDispatch, setTurbineToDispatch] = useState<TurbineData | null>(null);
@@ -66,7 +69,7 @@ const App: React.FC = () => {
     setTurbineToDispatch(null);
     setFaultAnalysisForDispatch('');
   }, []);
-  
+
   const handleConfirmDispatch = useCallback((turbineId: number, technicianId: number, faultDescription: string) => {
     maintenance.createWorkOrder(turbineId, turbines.find(t=>t.id === turbineId)?.name || '', faultDescription, technicianId);
     handleCloseDispatchModal();
@@ -84,9 +87,10 @@ const App: React.FC = () => {
 
 
   const activeWorkOrders = useMemo(() => workOrders.filter(wo => wo.status !== WorkOrderStatus.COMPLETED), [workOrders]);
-  
-  const farmStatus = turbines.some(t => t.status === TurbineStatus.FAULT) 
-    ? TurbineStatus.FAULT 
+
+  const faultCount = turbines.filter(t => t.status === TurbineStatus.FAULT).length;
+  const farmStatus = faultCount > 0
+    ? TurbineStatus.FAULT
     : turbines.every(t => t.status === TurbineStatus.OPERATING)
     ? TurbineStatus.OPERATING
     : TurbineStatus.IDLE;
@@ -101,25 +105,28 @@ const App: React.FC = () => {
       case TurbineStatus.OFFLINE: return 'text-gray-500';
     }
   };
-  
+
   const renderContent = () => {
     switch (view) {
         case 'dashboard':
             return selectedTurbine ? (
-              <TurbineDetail 
-                turbine={selectedTurbine} 
+              <TurbineDetail
+                turbine={selectedTurbine}
                 onBack={handleBackToOverview}
                 onDispatch={handleOpenDispatchModal}
                 activeWorkOrder={activeWorkOrders.find(wo => wo.turbineId === selectedTurbine.id)}
+                lang={lang}
               />
             ) : (
-              <FarmOverview turbines={turbines} onSelectTurbine={handleSelectTurbine} settings={settings} />
+              <FarmOverview turbines={turbines} onSelectTurbine={handleSelectTurbine} settings={settings} lang={lang} />
             );
         case 'maintenance':
-            return <MaintenanceHub 
+            return <MaintenanceHub
                 maintenanceData={maintenance}
                 onSelectWorkOrder={(wo) => setSelectedWorkOrder(wo)}
             />;
+        case 'faults':
+            return <FaultInjectionPanel lang={lang} />;
         case 'settings':
             return <SettingsPage settings={settings} onSave={saveSettings} />;
         default:
@@ -134,27 +141,42 @@ const App: React.FC = () => {
           <HeaderIcon />
           <h1 className="text-xl md:text-2xl font-bold font-orbitron text-white">Wind Farm SCADA</h1>
         </div>
-        <div className='flex items-center space-x-2'>
-            <NavButton isActive={view === 'dashboard'} onClick={() => setView('dashboard')}>
+        <div className='flex items-center space-x-1'>
+            <NavButton isActive={view === 'dashboard'} onClick={() => { setView('dashboard'); setSelectedTurbine(null); }}>
                 <ChartBarIcon />
-                <span>Dashboard</span>
+                <span className="hidden sm:inline">{ui('Dashboard', '儀表板')}</span>
             </NavButton>
             <NavButton isActive={view === 'maintenance'} onClick={() => setView('maintenance')}>
                 <WrenchScrewdriverIcon />
-                <span>Maintenance Hub</span>
+                <span className="hidden sm:inline">{ui('Maintenance', '維護中心')}</span>
+            </NavButton>
+            <NavButton isActive={view === 'faults'} onClick={() => setView('faults')}>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+                </svg>
+                <span className="hidden sm:inline">{ui('Faults', '故障模擬')}</span>
+                {faultCount > 0 && (
+                  <span className="ml-1 bg-red-500 text-white text-xs rounded-full w-5 h-5 flex items-center justify-center">{faultCount}</span>
+                )}
             </NavButton>
         </div>
-        <div className="flex items-center space-x-4">
+        <div className="flex items-center space-x-3">
             <div className="hidden md:flex items-center space-x-6 text-sm">
               <div>
-                <span className="text-gray-400">Total Power: </span>
+                <span className="text-gray-400">{ui('Total Power', '總功率')}: </span>
                 <span className="font-bold font-orbitron text-white">{totalPower.toFixed(2)} MW</span>
               </div>
               <div>
-                <span className="text-gray-400">Farm Status: </span>
+                <span className="text-gray-400">{ui('Status', '狀態')}: </span>
                 <span className={`font-bold ${getStatusColorClass(farmStatus)}`}>{farmStatus}</span>
               </div>
             </div>
+            {/* Language toggle */}
+            <button onClick={() => setLang(lang === 'zh' ? 'en' : 'zh')}
+              className="text-xs px-2 py-1 rounded border border-gray-600 text-gray-400 hover:text-white hover:border-gray-400 transition-colors"
+              title="Toggle language">
+              {lang === 'zh' ? 'EN' : '中文'}
+            </button>
              <button onClick={() => setView('settings')} title="Settings" className={`p-2 rounded-md transition-colors ${view === 'settings' ? 'bg-cyan-500/20 text-cyan-300' : 'text-gray-300 hover:bg-gray-700 hover:text-white'}`}>
                 <CogIcon />
             </button>
@@ -164,7 +186,7 @@ const App: React.FC = () => {
         {renderContent()}
       </main>
        <footer className="text-center p-4 text-xs text-gray-500 border-t border-gray-800">
-        Wind Farm SCADA System &copy; 2024. For demonstration purposes only.
+        Wind Farm SCADA System &copy; 2024. {ui('For demonstration purposes only.', '僅供展示使用。')}
       </footer>
 
       {isDispatchModalOpen && turbineToDispatch && (

--- a/frontend/components/FarmOverview.tsx
+++ b/frontend/components/FarmOverview.tsx
@@ -7,9 +7,15 @@ interface FarmOverviewProps {
   turbines: TurbineData[];
   onSelectTurbine: (turbine: TurbineData) => void;
   settings: AppSettings;
+  lang?: 'en' | 'zh';
 }
 
-const TurbineCard: React.FC<{ turbine: TurbineData; onSelect: (turbine: TurbineData) => void }> = ({ turbine, onSelect }) => {
+const TUR_STATE_SHORT: Record<number, string> = {
+  1: 'STOP', 2: 'STBY', 3: 'WAIT', 4: 'PREP',
+  5: 'START', 6: 'PROD', 7: 'SHTDN', 8: 'RSTR', 9: 'NSTP',
+};
+
+const TurbineCard: React.FC<{ turbine: TurbineData; onSelect: (turbine: TurbineData) => void; lang: string }> = ({ turbine, onSelect, lang }) => {
   const getStatusColorClasses = (status: TurbineStatus) => {
     switch (status) {
       case TurbineStatus.OPERATING:
@@ -23,25 +29,52 @@ const TurbineCard: React.FC<{ turbine: TurbineData; onSelect: (turbine: TurbineD
     }
   };
 
+  const hasFaults = turbine.activeFaults && turbine.activeFaults.length > 0;
+
   return (
     <div
       className={`relative rounded-lg p-4 border transition-all duration-300 cursor-pointer group ${getStatusColorClasses(turbine.status)}`}
       onClick={() => onSelect(turbine)}
     >
       <div className="flex justify-between items-start">
-        <h3 className="font-bold text-lg text-white">{turbine.name}</h3>
+        <div>
+          <h3 className="font-bold text-lg text-white">{turbine.name}</h3>
+          {turbine.turState && (
+            <span className="text-xs text-gray-500 font-mono">{TUR_STATE_SHORT[turbine.turState] || turbine.turState}</span>
+          )}
+        </div>
         <StatusIndicator status={turbine.status} />
       </div>
-      <div className="mt-4 flex items-end justify-between">
+      <div className="mt-3 flex items-end justify-between">
         <div>
-          <p className="text-xs text-gray-400">Power Output</p>
+          <p className="text-xs text-gray-400">{lang === 'zh' ? '發電功率' : 'Power'}</p>
           <p className="font-orbitron text-2xl font-bold text-white">{turbine.powerOutput.toFixed(2)} <span className="text-lg">MW</span></p>
         </div>
         <div className="text-right">
-          <p className="text-xs text-gray-400">Wind Speed</p>
+          <p className="text-xs text-gray-400">{lang === 'zh' ? '風速' : 'Wind'}</p>
           <p className="text-white">{turbine.windSpeed.toFixed(1)} m/s</p>
         </div>
       </div>
+      {/* Extra SCADA info row */}
+      <div className="mt-2 flex justify-between text-xs text-gray-500">
+        <span>{lang === 'zh' ? '轉速' : 'RPM'}: {turbine.rotorSpeed.toFixed(1)}</span>
+        <span>{lang === 'zh' ? '溫度' : 'Temp'}: {turbine.temperature.toFixed(0)}°C</span>
+        <span>{lang === 'zh' ? '振動' : 'Vib'}: {turbine.vibration.toFixed(1)}</span>
+      </div>
+      {/* Fault indicator */}
+      {hasFaults && (
+        <div className="mt-2 text-xs">
+          {turbine.activeFaults!.map((f, i) => (
+            <div key={i} className={`px-2 py-0.5 rounded text-xs ${
+              f.phase === 'critical' ? 'bg-red-500/30 text-red-300' :
+              f.phase === 'advanced' ? 'bg-orange-500/20 text-orange-300' :
+              'bg-yellow-500/20 text-yellow-300'
+            }`}>
+              {lang === 'zh' ? f.name_zh : f.name_en} ({(f.severity * 100).toFixed(0)}%)
+            </div>
+          ))}
+        </div>
+      )}
        <div className="absolute bottom-4 right-4 text-gray-600 group-hover:text-cyan-400 transition-colors">
           <WindTurbineIcon className="w-10 h-10 opacity-20 group-hover:opacity-40" />
        </div>
@@ -50,20 +83,20 @@ const TurbineCard: React.FC<{ turbine: TurbineData; onSelect: (turbine: TurbineD
 };
 
 
-const FarmOverview: React.FC<FarmOverviewProps> = ({ turbines, onSelectTurbine, settings }) => {
+const FarmOverview: React.FC<FarmOverviewProps> = ({ turbines, onSelectTurbine, settings, lang = 'zh' }) => {
   return (
     <div>
       <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-6">
-        <h2 className="text-3xl font-bold font-orbitron text-white">Farm Overview</h2>
-        {settings.dataSource !== DataSourceType.MOCK && (
+        <h2 className="text-3xl font-bold font-orbitron text-white">{lang === 'zh' ? '風場總覽' : 'Farm Overview'}</h2>
+        {settings.dataSource === DataSourceType.MOCK && (
           <div className="mt-2 md:mt-0 text-xs text-yellow-300 bg-yellow-900/50 border border-yellow-700 px-3 py-1 rounded-md">
-            Note: Data source is set to "{settings.dataSource}". Displaying MOCK DATA as a backend connection is not yet implemented.
+            {lang === 'zh' ? '注意: 使用前端模擬數據。請到設定頁面切換為「Physics Simulation」以使用後端模擬器。' : 'Using MOCK data. Switch to "Physics Simulation" in Settings for backend simulator.'}
           </div>
         )}
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
         {turbines.map(turbine => (
-          <TurbineCard key={turbine.id} turbine={turbine} onSelect={onSelectTurbine} />
+          <TurbineCard key={turbine.id} turbine={turbine} onSelect={onSelectTurbine} lang={lang} />
         ))}
       </div>
     </div>

--- a/frontend/components/FaultInjectionPanel.tsx
+++ b/frontend/components/FaultInjectionPanel.tsx
@@ -1,0 +1,154 @@
+import React, { useState, useEffect } from 'react';
+import type { FaultScenario } from '../types';
+
+const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8000';
+
+interface FaultInjectionPanelProps {
+  lang?: 'en' | 'zh';
+}
+
+const FaultInjectionPanel: React.FC<FaultInjectionPanelProps> = ({ lang = 'zh' }) => {
+  const [scenarios, setScenarios] = useState<FaultScenario[]>([]);
+  const [selectedScenario, setSelectedScenario] = useState('');
+  const [selectedTurbine, setSelectedTurbine] = useState('WT001');
+  const [severityRate, setSeverityRate] = useState('0.005');
+  const [activeFaults, setActiveFaults] = useState<any[]>([]);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    fetch(`${API_BASE}/api/faults/scenarios`)
+      .then(r => r.json()).then(setScenarios).catch(() => {});
+    refreshActive();
+    const iv = setInterval(refreshActive, 3000);
+    return () => clearInterval(iv);
+  }, []);
+
+  const refreshActive = () => {
+    fetch(`${API_BASE}/api/faults/active`)
+      .then(r => r.json()).then(setActiveFaults).catch(() => {});
+  };
+
+  const handleInject = async () => {
+    if (!selectedScenario) return;
+    const res = await fetch(`${API_BASE}/api/faults/inject`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        scenarioId: selectedScenario,
+        turbineId: selectedTurbine,
+        severityRate: parseFloat(severityRate),
+      }),
+    });
+    if (res.ok) {
+      setMessage(lang === 'zh' ? `已注入故障到 ${selectedTurbine}` : `Fault injected into ${selectedTurbine}`);
+      refreshActive();
+    }
+    setTimeout(() => setMessage(''), 3000);
+  };
+
+  const handleClearAll = async () => {
+    await fetch(`${API_BASE}/api/faults/clear`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    setMessage(lang === 'zh' ? '已清除所有故障' : 'All faults cleared');
+    refreshActive();
+    setTimeout(() => setMessage(''), 3000);
+  };
+
+  const phaseColors: Record<string, string> = {
+    incipient: 'text-yellow-400',
+    developing: 'text-orange-400',
+    advanced: 'text-red-400',
+    critical: 'text-red-300 font-bold',
+  };
+
+  const turbineOptions = Array.from({length: 14}, (_, i) => `WT${String(i+1).padStart(3, '0')}`);
+
+  return (
+    <div className="bg-gray-800/50 rounded-lg p-6 border border-gray-700">
+      <h3 className="text-xl font-bold text-white mb-4">
+        {lang === 'zh' ? '故障模擬控制台' : 'Fault Injection Console'}
+      </h3>
+
+      {/* Inject form */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3 mb-4">
+        <select value={selectedScenario} onChange={e => setSelectedScenario(e.target.value)}
+          className="bg-gray-700 text-white rounded px-3 py-2 text-sm">
+          <option value="">{lang === 'zh' ? '-- 選擇故障場景 --' : '-- Select Scenario --'}</option>
+          {scenarios.map(s => (
+            <option key={s.id} value={s.id}>{lang === 'zh' ? s.name_zh : s.name_en}</option>
+          ))}
+        </select>
+        <select value={selectedTurbine} onChange={e => setSelectedTurbine(e.target.value)}
+          className="bg-gray-700 text-white rounded px-3 py-2 text-sm">
+          {turbineOptions.map(t => <option key={t} value={t}>{t}</option>)}
+        </select>
+        <div className="flex items-center space-x-2">
+          <label className="text-gray-400 text-xs whitespace-nowrap">{lang === 'zh' ? '速率' : 'Rate'}:</label>
+          <input type="number" step="0.001" min="0.0001" max="0.1" value={severityRate}
+            onChange={e => setSeverityRate(e.target.value)}
+            className="bg-gray-700 text-white rounded px-3 py-2 text-sm w-full" />
+        </div>
+        <button onClick={handleInject} disabled={!selectedScenario}
+          className="bg-red-600 hover:bg-red-700 disabled:bg-gray-600 text-white font-bold py-2 px-4 rounded text-sm transition-colors">
+          {lang === 'zh' ? '注入故障' : 'Inject Fault'}
+        </button>
+        <button onClick={handleClearAll}
+          className="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded text-sm transition-colors">
+          {lang === 'zh' ? '清除全部' : 'Clear All'}
+        </button>
+      </div>
+
+      {message && (
+        <div className="mb-3 text-sm text-cyan-300 bg-cyan-900/30 px-3 py-1 rounded">{message}</div>
+      )}
+
+      {/* Active faults table */}
+      {activeFaults.length > 0 && (
+        <div className="mt-4">
+          <h4 className="text-sm text-gray-400 mb-2">{lang === 'zh' ? '活躍故障' : 'Active Faults'} ({activeFaults.length})</h4>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-gray-500 text-xs border-b border-gray-700">
+                  <th className="text-left py-1 px-2">{lang === 'zh' ? '風機' : 'Turbine'}</th>
+                  <th className="text-left py-1 px-2">{lang === 'zh' ? '故障' : 'Fault'}</th>
+                  <th className="text-left py-1 px-2">{lang === 'zh' ? '嚴重度' : 'Severity'}</th>
+                  <th className="text-left py-1 px-2">{lang === 'zh' ? '階段' : 'Phase'}</th>
+                  <th className="text-left py-1 px-2">{lang === 'zh' ? '告警' : 'Alarms'}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {activeFaults.map((f, i) => (
+                  <tr key={i} className="border-b border-gray-800">
+                    <td className="py-1.5 px-2 text-white font-mono">{f.turbine_id}</td>
+                    <td className="py-1.5 px-2 text-gray-300">{lang === 'zh' ? f.name_zh : f.name_en}</td>
+                    <td className="py-1.5 px-2">
+                      <div className="flex items-center space-x-2">
+                        <div className="w-20 h-2 bg-gray-700 rounded-full overflow-hidden">
+                          <div className={`h-full rounded-full ${f.severity > 0.7 ? 'bg-red-500' : f.severity > 0.4 ? 'bg-orange-500' : 'bg-yellow-500'}`}
+                            style={{width: `${f.severity * 100}%`}} />
+                        </div>
+                        <span className="text-gray-400 text-xs">{(f.severity * 100).toFixed(0)}%</span>
+                      </div>
+                    </td>
+                    <td className={`py-1.5 px-2 text-xs capitalize ${phaseColors[f.phase] || ''}`}>
+                      {f.phase} {f.tripped && '(TRIP)'}
+                    </td>
+                    <td className="py-1.5 px-2 text-xs text-gray-500">
+                      {f.active_alarms?.map((a: any) => `[${a.type}]`).join(' ') || '-'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default FaultInjectionPanel;

--- a/frontend/components/TurbineDetail.tsx
+++ b/frontend/components/TurbineDetail.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react';
-import { type TurbineData, TurbineStatus, type WorkOrder, WorkOrderStatus, TechnicianStatus } from '../types';
+import { type TurbineData, TurbineStatus, type WorkOrder, WorkOrderStatus, type FaultInfo } from '../types';
 import StatusIndicator from './StatusIndicator';
 import Gauge from './Gauge';
 import MiniTrendChart from './MiniTrendChart';
@@ -12,20 +12,79 @@ interface TurbineDetailProps {
   onBack: () => void;
   onDispatch: (turbine: TurbineData, faultAnalysis: string) => void;
   activeWorkOrder?: WorkOrder;
+  lang?: 'en' | 'zh';
 }
 
-const TurbineDetail: React.FC<TurbineDetailProps> = ({ turbine, onBack, onDispatch, activeWorkOrder }) => {
+const TUR_STATE_LABELS: Record<number, { en: string; zh: string }> = {
+  1: { en: 'Shutdown', zh: '自動停機' },
+  2: { en: 'Standby', zh: '待機中' },
+  3: { en: 'Wait Restart', zh: '等待重啟' },
+  4: { en: 'Pre-Production', zh: '發電準備' },
+  5: { en: 'Start Production', zh: '啟動發電' },
+  6: { en: 'Production', zh: '正常發電' },
+  7: { en: 'Shutting Down', zh: '停機中' },
+  8: { en: 'Restart', zh: '重新啟動' },
+  9: { en: 'Normal Stop', zh: '正常停機' },
+};
+
+const fmt = (v: number | undefined | null, digits = 1): string =>
+  v != null ? v.toFixed(digits) : '--';
+
+// Subsystem panel component
+const SubsystemPanel: React.FC<{ title: string; children: React.ReactNode; color?: string }> = ({ title, children, color = 'cyan' }) => (
+  <div className={`bg-gray-800/50 rounded-lg p-4 border border-${color}-500/20`}>
+    <h4 className={`text-sm font-semibold text-${color}-400 mb-3 uppercase tracking-wider`}>{title}</h4>
+    <div className="space-y-2">
+      {children}
+    </div>
+  </div>
+);
+
+const DataRow: React.FC<{ label: string; value: string; warn?: boolean; alert?: boolean }> = ({ label, value, warn, alert }) => (
+  <div className="flex justify-between items-center">
+    <span className="text-gray-400 text-sm">{label}</span>
+    <span className={`font-mono text-sm font-semibold ${alert ? 'text-red-400' : warn ? 'text-yellow-400' : 'text-white'}`}>
+      {value}
+    </span>
+  </div>
+);
+
+const FaultBadge: React.FC<{ fault: FaultInfo; lang: string }> = ({ fault, lang }) => {
+  const phaseColors: Record<string, string> = {
+    incipient: 'bg-yellow-500/20 text-yellow-300 border-yellow-500/50',
+    developing: 'bg-orange-500/20 text-orange-300 border-orange-500/50',
+    advanced: 'bg-red-500/20 text-red-300 border-red-500/50',
+    critical: 'bg-red-600/30 text-red-200 border-red-500 animate-pulse',
+  };
+  return (
+    <div className={`px-3 py-2 rounded-md border text-sm ${phaseColors[fault.phase] || ''}`}>
+      <div className="font-bold">{lang === 'zh' ? fault.name_zh : fault.name_en}</div>
+      <div className="flex items-center space-x-3 mt-1 text-xs">
+        <span>Severity: {(fault.severity * 100).toFixed(1)}%</span>
+        <span className="capitalize">{fault.phase}</span>
+        {fault.tripped && <span className="text-red-400 font-bold">TRIPPED</span>}
+      </div>
+      {fault.active_alarms.length > 0 && (
+        <div className="mt-1 space-y-0.5">
+          {fault.active_alarms.map((a, i) => (
+            <div key={i} className="text-xs opacity-80">[{a.type}] {a.desc}</div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const TurbineDetail: React.FC<TurbineDetailProps> = ({ turbine, onBack, onDispatch, activeWorkOrder, lang = 'zh' }) => {
     const [isAnalyzing, setIsAnalyzing] = useState(false);
     const [analysisResult, setAnalysisResult] = useState<string | null>(null);
     const [analysisError, setAnalysisError] = useState<string | null>(null);
-    
-    // Auto-run analysis when viewing a faulted turbine if no analysis has been run yet.
+
     useEffect(() => {
         if(turbine.status === TurbineStatus.FAULT && !analysisResult && !isAnalyzing) {
             handleAnalyzeFault();
         }
     }, [turbine.status, analysisResult, isAnalyzing]);
-
 
     const handleAnalyzeFault = useCallback(async () => {
         setIsAnalyzing(true);
@@ -51,73 +110,160 @@ const TurbineDetail: React.FC<TurbineDetailProps> = ({ turbine, onBack, onDispat
         return <p key={index}>{line}</p>;
     });
 
+    const turStateLabel = TUR_STATE_LABELS[turbine.turState || 0];
+    const turStateText = turStateLabel ? (lang === 'zh' ? turStateLabel.zh : turStateLabel.en) : `State ${turbine.turState}`;
+    const hasFaults = turbine.activeFaults && turbine.activeFaults.length > 0;
+
   return (
     <div>
         <button onClick={onBack} className="flex items-center space-x-2 text-cyan-400 hover:text-cyan-300 mb-6 transition-colors">
             <BackIcon />
-            <span>Back to Farm Overview</span>
+            <span>{lang === 'zh' ? '返回風場總覽' : 'Back to Farm Overview'}</span>
         </button>
 
+      {/* Header */}
       <div className="bg-gray-800/50 rounded-lg p-6 mb-6">
         <div className="flex flex-col sm:flex-row justify-between sm:items-center">
-            <h2 className="text-4xl font-bold font-orbitron text-white">{turbine.name}</h2>
+            <div>
+              <h2 className="text-4xl font-bold font-orbitron text-white">{turbine.name}</h2>
+              <div className="flex items-center space-x-3 mt-2 text-sm">
+                <span className="text-gray-400">TurState: <span className="text-white font-semibold">{turbine.turState} - {turStateText}</span></span>
+                {turbine.outsideTemp != null && (
+                  <span className="text-gray-400">{lang === 'zh' ? '室外' : 'Outdoor'}: <span className="text-white">{fmt(turbine.outsideTemp)}°C</span></span>
+                )}
+                {turbine.windDirection != null && (
+                  <span className="text-gray-400">{lang === 'zh' ? '風向' : 'Wind Dir'}: <span className="text-white">{fmt(turbine.windDirection, 0)}°</span></span>
+                )}
+              </div>
+            </div>
             <div className="mt-2 sm:mt-0"><StatusIndicator status={turbine.status} large /></div>
         </div>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-        {/* Gauges */}
-        <Gauge value={turbine.powerOutput} maxValue={5} label="Power Output" unit="MW" />
-        <Gauge value={turbine.rotorSpeed} maxValue={25} label="Rotor Speed" unit="RPM" />
-        <Gauge value={turbine.windSpeed} maxValue={25} label="Wind Speed" unit="m/s" />
+      {/* Fault alerts */}
+      {hasFaults && (
+        <div className="mb-6 space-y-2">
+          {turbine.activeFaults!.map((f, i) => (
+            <FaultBadge key={i} fault={f} lang={lang} />
+          ))}
+        </div>
+      )}
 
-        {/* Trend Chart */}
-        <div className="md:col-span-2 lg:col-span-1 bg-gray-800/50 p-4 rounded-lg flex flex-col justify-center">
-           <h3 className="text-gray-400 text-sm mb-2 text-center">Power Trend (Last Minute)</h3>
+      {/* Gauges row */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
+        <Gauge value={turbine.powerOutput} maxValue={5} label={lang === 'zh' ? '發電功率' : 'Power Output'} unit="MW" />
+        <Gauge value={turbine.rotorSpeed} maxValue={15} label={lang === 'zh' ? '葉輪轉速' : 'Rotor Speed'} unit="RPM" />
+        <Gauge value={turbine.windSpeed} maxValue={25} label={lang === 'zh' ? '風速' : 'Wind Speed'} unit="m/s" />
+        <div className="bg-gray-800/50 p-4 rounded-lg flex flex-col justify-center">
+           <h3 className="text-gray-400 text-sm mb-2 text-center">{lang === 'zh' ? '功率趨勢' : 'Power Trend'}</h3>
            <MiniTrendChart data={turbine.history} />
         </div>
-
-        {/* Data Cards */}
-        <DataCard icon={<BoltIcon />} label="Voltage / Current" value={`${turbine.voltage.toFixed(0)} V / ${turbine.current.toFixed(0)} A`} />
-        <DataCard icon={<TempIcon />} label="Nacelle Temperature" value={`${turbine.temperature.toFixed(1)} °C`} />
-        <DataCard icon={<VibrationIcon />} label="Vibration" value={`${turbine.vibration.toFixed(2)} mm/s`} />
-        <DataCard icon={<AngleIcon />} label="Blade Angle" value={`${turbine.bladeAngle.toFixed(1)} °`} />
       </div>
 
+      {/* SCADA subsystem panels */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
+        {/* Generator */}
+        <SubsystemPanel title={lang === 'zh' ? 'WGEN 發電機' : 'WGEN Generator'}>
+          <DataRow label={lang === 'zh' ? '功率' : 'Power'} value={`${fmt(turbine.genPower)} kW`} />
+          <DataRow label={lang === 'zh' ? '轉速' : 'Speed'} value={`${fmt(turbine.genSpeed, 0)} RPM`} />
+          <DataRow label={lang === 'zh' ? '電壓' : 'Voltage'} value={`${fmt(turbine.voltage, 0)} V`} />
+          <DataRow label={lang === 'zh' ? '電流' : 'Current'} value={`${fmt(turbine.current, 0)} A`} />
+          <DataRow label={lang === 'zh' ? '定子溫度' : 'Stator Temp'} value={`${fmt(turbine.genStatorTemp1)}°C`}
+            warn={(turbine.genStatorTemp1 || 0) > 100} alert={(turbine.genStatorTemp1 || 0) > 130} />
+          <DataRow label={lang === 'zh' ? '氣隙溫度' : 'Air Gap Temp'} value={`${fmt(turbine.genAirTemp1)}°C`}
+            warn={(turbine.genAirTemp1 || 0) > 80} />
+          <DataRow label={lang === 'zh' ? '軸承溫度' : 'Bearing Temp'} value={`${fmt(turbine.genBearingTemp1)}°C`}
+            warn={(turbine.genBearingTemp1 || 0) > 70} alert={(turbine.genBearingTemp1 || 0) > 90} />
+        </SubsystemPanel>
+
+        {/* Rotor / Pitch */}
+        <SubsystemPanel title={lang === 'zh' ? 'WROT 葉輪/旋角' : 'WROT Rotor/Pitch'} color="green">
+          <DataRow label={lang === 'zh' ? '葉輪轉速' : 'Rotor RPM'} value={`${fmt(turbine.rotorSpeed, 2)} RPM`} />
+          <DataRow label={lang === 'zh' ? '葉片1角度' : 'Blade 1'} value={`${fmt(turbine.bladeAngle1)}°`} />
+          <DataRow label={lang === 'zh' ? '葉片2角度' : 'Blade 2'} value={`${fmt(turbine.bladeAngle2)}°`} />
+          <DataRow label={lang === 'zh' ? '葉片3角度' : 'Blade 3'} value={`${fmt(turbine.bladeAngle3)}°`} />
+          <DataRow label={lang === 'zh' ? '轉子溫度' : 'Rotor Temp'} value={`${fmt(turbine.rotorTemp)}°C`} />
+          <DataRow label={lang === 'zh' ? '輪毂櫃溫' : 'Hub Cab Temp'} value={`${fmt(turbine.hubCabinetTemp)}°C`} />
+          <DataRow label={lang === 'zh' ? '鎖固/剎車' : 'Locked/Brake'}
+            value={`${turbine.rotorLocked ? 'Locked' : '-'} / ${turbine.brakeActive ? 'Active' : '-'}`} />
+        </SubsystemPanel>
+
+        {/* Converter */}
+        <SubsystemPanel title={lang === 'zh' ? 'WCNV 變頻器' : 'WCNV Converter'} color="purple">
+          <DataRow label={lang === 'zh' ? '發電機功率' : 'Gen Power'} value={`${fmt(turbine.cnvGenPower)} kW`} />
+          <DataRow label={lang === 'zh' ? '電網功率' : 'Grid Power'} value={`${fmt(turbine.cnvGridPower)} kW`} />
+          <DataRow label={lang === 'zh' ? '頻率' : 'Frequency'} value={`${fmt(turbine.cnvGenFreq, 2)} Hz`} />
+          <DataRow label={lang === 'zh' ? 'DC電壓' : 'DC Voltage'} value={`${fmt(turbine.cnvDcVoltage, 0)} V`} />
+          <DataRow label={lang === 'zh' ? '控制櫃溫度' : 'Cabinet Temp'} value={`${fmt(turbine.cnvCabinetTemp)}°C`}
+            warn={(turbine.cnvCabinetTemp || 0) > 45} />
+          <DataRow label={lang === 'zh' ? 'IGCT水溫' : 'IGCT Water Temp'} value={`${fmt(turbine.igctWaterTemp)}°C`}
+            warn={(turbine.igctWaterTemp || 0) > 40} />
+          <DataRow label={lang === 'zh' ? 'IGCT水壓' : 'IGCT Pressure'} value={`${fmt(turbine.igctWaterPres1)} / ${fmt(turbine.igctWaterPres2)} bar`} />
+        </SubsystemPanel>
+
+        {/* Nacelle */}
+        <SubsystemPanel title={lang === 'zh' ? 'WNAC 機艙' : 'WNAC Nacelle'} color="yellow">
+          <DataRow label={lang === 'zh' ? '機艙溫度' : 'Nacelle Temp'} value={`${fmt(turbine.nacelleTemp)}°C`} />
+          <DataRow label={lang === 'zh' ? '控制櫃溫度' : 'Cabinet Temp'} value={`${fmt(turbine.nacelleCabTemp)}°C`} />
+          <DataRow label={lang === 'zh' ? 'X方向振動' : 'Vibration X'} value={`${fmt(turbine.vibrationX, 2)} mm/s`}
+            warn={(turbine.vibrationX || 0) > 4} alert={(turbine.vibrationX || 0) > 8} />
+          <DataRow label={lang === 'zh' ? 'Y方向振動' : 'Vibration Y'} value={`${fmt(turbine.vibrationY, 2)} mm/s`}
+            warn={(turbine.vibrationY || 0) > 4} alert={(turbine.vibrationY || 0) > 8} />
+        </SubsystemPanel>
+
+        {/* Yaw */}
+        <SubsystemPanel title={lang === 'zh' ? 'WYAW 轉向系統' : 'WYAW Yaw System'} color="blue">
+          <DataRow label={lang === 'zh' ? '風向誤差(5s)' : 'Yaw Error (5s)'} value={`${fmt(turbine.yawError)}°`}
+            warn={Math.abs(turbine.yawError || 0) > 10} />
+          <DataRow label={lang === 'zh' ? '剎車液壓' : 'Brake Pressure'} value={`${fmt(turbine.yawBrakePressure, 0)} bar`} />
+          <DataRow label={lang === 'zh' ? '纜線圈數' : 'Cable Windup'} value={`${fmt(turbine.cableWindup, 2)} turns`}
+            warn={Math.abs(turbine.cableWindup || 0) > 3} />
+        </SubsystemPanel>
+
+        {/* Grid / Transformer + Met */}
+        <SubsystemPanel title={lang === 'zh' ? 'WGDC/WMET 電網/氣象' : 'WGDC/WMET Grid/Met'} color="orange">
+          <DataRow label={lang === 'zh' ? '變壓器溫度' : 'Transformer Temp'} value={`${fmt(turbine.transformerTemp)}°C`}
+            warn={(turbine.transformerTemp || 0) > 80} />
+          <DataRow label={lang === 'zh' ? '風速' : 'Wind Speed'} value={`${fmt(turbine.windSpeed)} m/s`} />
+          <DataRow label={lang === 'zh' ? '風向' : 'Wind Dir'} value={`${fmt(turbine.windDirection, 0)}°`} />
+          <DataRow label={lang === 'zh' ? '室外溫度' : 'Outside Temp'} value={`${fmt(turbine.outsideTemp)}°C`} />
+        </SubsystemPanel>
+      </div>
+
+      {/* AI Fault Diagnosis */}
       {turbine.status === TurbineStatus.FAULT && (
          <div className="mt-6 bg-red-900/30 border border-red-500/50 rounded-lg p-6">
             <div className="flex flex-col md:flex-row md:items-start justify-between">
                 <div>
-                    <h3 className="text-xl font-bold text-red-300">AI Fault Diagnosis</h3>
-                    <p className="text-red-400 mt-1">Experimental AI analysis to help diagnose the issue.</p>
+                    <h3 className="text-xl font-bold text-red-300">{lang === 'zh' ? 'AI 故障診斷' : 'AI Fault Diagnosis'}</h3>
+                    <p className="text-red-400 mt-1">{lang === 'zh' ? '實驗性 AI 分析協助故障診斷' : 'Experimental AI analysis to help diagnose the issue.'}</p>
                 </div>
                 <div className="flex space-x-2 mt-4 md:mt-0">
-                    <button 
-                        onClick={handleAnalyzeFault} 
+                    <button
+                        onClick={handleAnalyzeFault}
                         disabled={isAnalyzing}
                         className="flex items-center justify-center space-x-2 bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-lg transition-all disabled:bg-gray-800 disabled:cursor-not-allowed"
                     >
                         <BrainIcon />
-                        <span>{isAnalyzing ? 'Analyzing...' : 'Re-Analyze'}</span>
+                        <span>{isAnalyzing ? (lang === 'zh' ? '分析中...' : 'Analyzing...') : (lang === 'zh' ? '重新分析' : 'Re-Analyze')}</span>
                     </button>
-
                     {activeWorkOrder ? (
                         <div className="text-center py-2 px-4 rounded-lg bg-yellow-500/20 text-yellow-300 border border-yellow-500/50">
-                            <p className="font-bold">Work Order #{activeWorkOrder.id.slice(-4)} In Progress</p>
+                            <p className="font-bold">{lang === 'zh' ? '工單' : 'WO'} #{activeWorkOrder.id.slice(-4)} {lang === 'zh' ? '處理中' : 'In Progress'}</p>
                         </div>
                     ) : (
-                        <button 
-                            onClick={() => onDispatch(turbine, analysisResult || "Awaiting analysis...")} 
+                        <button
+                            onClick={() => onDispatch(turbine, analysisResult || "Awaiting analysis...")}
                             disabled={isAnalyzing || !analysisResult}
                             className="flex items-center justify-center space-x-2 bg-yellow-500 hover:bg-yellow-600 text-white font-bold py-2 px-4 rounded-lg transition-all disabled:bg-yellow-800 disabled:cursor-not-allowed w-full md:w-auto"
                         >
                             <WrenchScrewdriverIcon />
-                            <span>Dispatch Technician</span>
+                            <span>{lang === 'zh' ? '派遣技術員' : 'Dispatch Technician'}</span>
                         </button>
                     )}
                 </div>
             </div>
-            {isAnalyzing && <div className="mt-4 text-center text-red-300 animate-pulse">Contacting maintenance AI, please wait...</div>}
+            {isAnalyzing && <div className="mt-4 text-center text-red-300 animate-pulse">{lang === 'zh' ? '正在聯繫維護 AI...' : 'Contacting maintenance AI...'}</div>}
             {analysisError && <div className="mt-4 text-center font-bold text-red-200 bg-red-500/30 p-3 rounded">{analysisError}</div>}
             {analysisResult && (
                 <div className="mt-4 bg-gray-900/50 p-4 rounded-md text-gray-300 font-mono text-sm leading-relaxed">

--- a/frontend/hooks/useI18n.ts
+++ b/frontend/hooks/useI18n.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { ScadaTagI18n } from '../types';
+
+const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8000';
+const STORAGE_KEY = 'windFarmLang';
+
+export type Lang = 'en' | 'zh';
+
+export const useI18n = () => {
+  const [lang, setLangState] = useState<Lang>(
+    () => (localStorage.getItem(STORAGE_KEY) as Lang) || 'zh'
+  );
+  const [tagLabels, setTagLabels] = useState<ScadaTagI18n>({});
+
+  useEffect(() => {
+    fetch(`${API_BASE}/api/i18n/tags/all`)
+      .then(res => res.json())
+      .then(setTagLabels)
+      .catch(() => {});
+  }, []);
+
+  const setLang = useCallback((newLang: Lang) => {
+    setLangState(newLang);
+    localStorage.setItem(STORAGE_KEY, newLang);
+  }, []);
+
+  const t = useCallback((tagId: string): string => {
+    const entry = tagLabels[tagId];
+    if (!entry) return tagId;
+    return lang === 'zh' ? entry.zh : entry.en;
+  }, [tagLabels, lang]);
+
+  // UI labels (non-SCADA)
+  const ui = useCallback((en: string, zh: string): string => {
+    return lang === 'zh' ? zh : en;
+  }, [lang]);
+
+  return { lang, setLang, t, ui };
+};

--- a/frontend/hooks/useRealtimeData.ts
+++ b/frontend/hooks/useRealtimeData.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { type TurbineData, TurbineStatus } from '../types';
+import { type TurbineData, TurbineStatus, type FaultInfo } from '../types';
 
 const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8000';
 const WS_URL = import.meta.env.VITE_WS_URL || 'ws://localhost:8000/ws/realtime';
@@ -9,6 +9,7 @@ interface ApiTurbineReading {
   name: string;
   timestamp: string;
   status: string;
+  turState: number;
   windSpeed: number;
   powerOutput: number;
   rotorSpeed: number;
@@ -22,6 +23,40 @@ interface ApiTurbineReading {
   frequency: number | null;
   hydraulicPressure: number | null;
   history: { time: number; power: number }[] | null;
+  // Extended SCADA fields
+  genPower?: number;
+  genSpeed?: number;
+  genStatorTemp1?: number;
+  genAirTemp1?: number;
+  genBearingTemp1?: number;
+  bladeAngle1?: number;
+  bladeAngle2?: number;
+  bladeAngle3?: number;
+  rotorTemp?: number;
+  hubCabinetTemp?: number;
+  rotorLocked?: number;
+  brakeActive?: number;
+  cnvCabinetTemp?: number;
+  cnvDcVoltage?: number;
+  cnvGridPower?: number;
+  cnvGenFreq?: number;
+  cnvGenPower?: number;
+  igctWaterCond?: number;
+  igctWaterPres1?: number;
+  igctWaterPres2?: number;
+  igctWaterTemp?: number;
+  transformerTemp?: number;
+  windDirection?: number;
+  outsideTemp?: number;
+  nacelleTemp?: number;
+  nacelleCabTemp?: number;
+  vibrationX?: number;
+  vibrationY?: number;
+  yawError?: number;
+  yawBrakePressure?: number;
+  cableWindup?: number;
+  activeFaults?: FaultInfo[];
+  scadaTags?: Record<string, number>;
 }
 
 function mapStatus(status: string): TurbineStatus {
@@ -39,6 +74,7 @@ function apiToTurbineData(api: ApiTurbineReading, index: number): TurbineData {
     id: index + 1,
     name: api.name,
     status: mapStatus(api.status),
+    turState: api.turState,
     powerOutput: api.powerOutput,
     windSpeed: api.windSpeed,
     rotorSpeed: api.rotorSpeed,
@@ -48,6 +84,40 @@ function apiToTurbineData(api: ApiTurbineReading, index: number): TurbineData {
     voltage: api.voltage,
     current: api.current,
     history: api.history || [],
+    // Extended fields
+    genPower: api.genPower,
+    genSpeed: api.genSpeed,
+    genStatorTemp1: api.genStatorTemp1,
+    genAirTemp1: api.genAirTemp1,
+    genBearingTemp1: api.genBearingTemp1,
+    bladeAngle1: api.bladeAngle1,
+    bladeAngle2: api.bladeAngle2,
+    bladeAngle3: api.bladeAngle3,
+    rotorTemp: api.rotorTemp,
+    hubCabinetTemp: api.hubCabinetTemp,
+    rotorLocked: api.rotorLocked,
+    brakeActive: api.brakeActive,
+    cnvCabinetTemp: api.cnvCabinetTemp,
+    cnvDcVoltage: api.cnvDcVoltage,
+    cnvGridPower: api.cnvGridPower,
+    cnvGenFreq: api.cnvGenFreq,
+    cnvGenPower: api.cnvGenPower,
+    igctWaterCond: api.igctWaterCond,
+    igctWaterPres1: api.igctWaterPres1,
+    igctWaterPres2: api.igctWaterPres2,
+    igctWaterTemp: api.igctWaterTemp,
+    transformerTemp: api.transformerTemp,
+    windDirection: api.windDirection,
+    outsideTemp: api.outsideTemp,
+    nacelleTemp: api.nacelleTemp,
+    nacelleCabTemp: api.nacelleCabTemp,
+    vibrationX: api.vibrationX,
+    vibrationY: api.vibrationY,
+    yawError: api.yawError,
+    yawBrakePressure: api.yawBrakePressure,
+    cableWindup: api.cableWindup,
+    activeFaults: api.activeFaults,
+    scadaTags: api.scadaTags,
   };
 }
 
@@ -76,7 +146,6 @@ export const useRealtimeData = () => {
 
       ws.onopen = () => {
         console.log('[WS] Connected to', WS_URL);
-        // Send a ping to keep connection alive
         ws.send('ping');
       };
 


### PR DESCRIPTION
… i18n

- TurbineDetail: 6 subsystem panels (WGEN/WROT/WCNV/WNAC/WYAW/WGDC) with all 40 SCADA tags, color-coded warning/alert thresholds
- FarmOverview: cards now show TurState, RPM/temp/vibration, fault badges
- FaultInjectionPanel: inject/monitor/clear faults with severity progress bars
- useI18n hook: zh-TW/English toggle with localStorage persistence
- useRealtimeData: maps all new SCADA fields from backend API
- App.tsx: language toggle in header, fault nav with badge counter

https://claude.ai/code/session_01QXekwDWAdCEfjvTwDqYHjd