### PR TITLE
feat: add wind condition control (profiles + custom override)

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -128,7 +128,7 @@ const App: React.FC = () => {
         case 'faults':
             return <FaultInjectionPanel lang={lang} />;
         case 'settings':
-            return <SettingsPage settings={settings} onSave={saveSettings} />;
+            return <SettingsPage settings={settings} onSave={saveSettings} lang={lang} />;
         default:
             return null;
     }

--- a/frontend/components/SettingsPage.tsx
+++ b/frontend/components/SettingsPage.tsx
@@ -1,14 +1,71 @@
 import React, { useState, useEffect } from 'react';
 import { type AppSettings, DataSourceType } from '../types';
 
+const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8000';
+
 interface SettingsPageProps {
     settings: AppSettings;
     onSave: (settings: AppSettings) => void;
+    lang?: 'en' | 'zh';
 }
 
-const SettingsPage: React.FC<SettingsPageProps> = ({ settings, onSave }) => {
+const WIND_PROFILES = [
+    { id: 'auto', en: 'Auto (Daily Pattern)', zh: '自動（日變化模式）' },
+    { id: 'calm', en: 'Calm (2 m/s) — Turbines Idle', zh: '平靜 (2 m/s) — 風機待機' },
+    { id: 'moderate', en: 'Moderate (8 m/s) — Partial Load', zh: '中等 (8 m/s) — 部分負載' },
+    { id: 'rated', en: 'Rated (12 m/s) — Full Power', zh: '額定 (12 m/s) — 滿載發電' },
+    { id: 'strong', en: 'Strong (18 m/s) — Pitch Active', zh: '強風 (18 m/s) — 變槳調節' },
+    { id: 'storm', en: 'Storm (26 m/s) — Emergency Stop', zh: '暴風 (26 m/s) — 緊急停機' },
+    { id: 'gusty', en: 'Gusty (10 m/s, high turbulence)', zh: '陣風 (10 m/s, 高湍流)' },
+    { id: 'ramp_up', en: 'Ramp Up (3→15 m/s)', zh: '漸增 (3→15 m/s)' },
+    { id: 'ramp_down', en: 'Ramp Down (15→3 m/s)', zh: '漸減 (15→3 m/s)' },
+];
+
+const SettingsPage: React.FC<SettingsPageProps> = ({ settings, onSave, lang = 'zh' }) => {
     const [formData, setFormData] = useState<AppSettings>(settings);
     const [saveStatus, setSaveStatus] = useState<'idle' | 'success'>('idle');
+
+    // Wind control state
+    const [windStatus, setWindStatus] = useState<any>(null);
+    const [windProfile, setWindProfile] = useState('auto');
+    const [customWind, setCustomWind] = useState({ speed: '10', direction: '270', temp: '25', turbulence: '0.1' });
+    const [windMsg, setWindMsg] = useState('');
+
+    const refreshWindStatus = () => {
+        fetch(`${API_BASE}/api/config/wind`).then(r => r.json()).then(setWindStatus).catch(() => {});
+    };
+
+    useEffect(() => {
+        refreshWindStatus();
+        const iv = setInterval(refreshWindStatus, 5000);
+        return () => clearInterval(iv);
+    }, []);
+
+    const handleSetProfile = async (profile: string) => {
+        setWindProfile(profile);
+        await fetch(`${API_BASE}/api/config/wind`, {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ profile }),
+        });
+        setWindMsg(lang === 'zh' ? `已切換: ${profile}` : `Switched to: ${profile}`);
+        refreshWindStatus();
+        setTimeout(() => setWindMsg(''), 3000);
+    };
+
+    const handleSetCustomWind = async () => {
+        await fetch(`${API_BASE}/api/config/wind`, {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                windSpeed: parseFloat(customWind.speed) || null,
+                windDirection: parseFloat(customWind.direction) || null,
+                ambientTemp: parseFloat(customWind.temp) || null,
+                turbulence: parseFloat(customWind.turbulence) || null,
+            }),
+        });
+        setWindMsg(lang === 'zh' ? '已套用自訂風況' : 'Custom wind applied');
+        refreshWindStatus();
+        setTimeout(() => setWindMsg(''), 3000);
+    };
 
     useEffect(() => {
         setFormData(settings);
@@ -196,6 +253,86 @@ const SettingsPage: React.FC<SettingsPageProps> = ({ settings, onSave }) => {
                                         />
                                     </div>
                                 </div>
+                            </div>
+                        )}
+
+                        {/* Wind Condition Control */}
+                        {(formData.dataSource === DataSourceType.SIMULATION) && (
+                            <div className="bg-gray-900/50 p-4 rounded-md border-l-4 border-blue-500">
+                                <h3 className="text-lg font-semibold text-white mb-3">
+                                    {lang === 'zh' ? '風況控制' : 'Wind Condition Control'}
+                                </h3>
+
+                                {/* Current status */}
+                                {windStatus && (
+                                    <div className="mb-3 text-sm text-gray-400">
+                                        {lang === 'zh' ? '目前模式' : 'Current mode'}: <span className="text-white font-semibold">{windStatus.mode}</span>
+                                        {windStatus.profile && <span className="ml-2">({windStatus.profile})</span>}
+                                        {windStatus.override_wind_speed != null && (
+                                            <span className="ml-3">{lang === 'zh' ? '風速' : 'Wind'}: <span className="text-cyan-300">{windStatus.override_wind_speed} m/s</span></span>
+                                        )}
+                                    </div>
+                                )}
+
+                                {/* Profile quick buttons */}
+                                <div className="mb-4">
+                                    <label className="block text-sm text-gray-300 mb-2">{lang === 'zh' ? '快速情境' : 'Quick Profiles'}</label>
+                                    <div className="flex flex-wrap gap-2">
+                                        {WIND_PROFILES.map(p => (
+                                            <button key={p.id} onClick={() => handleSetProfile(p.id)}
+                                                className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
+                                                    windProfile === p.id || windStatus?.profile === p.id
+                                                    ? 'bg-blue-600 border-blue-500 text-white'
+                                                    : 'bg-gray-700 border-gray-600 text-gray-300 hover:border-blue-400'
+                                                }`}>
+                                                {lang === 'zh' ? p.zh : p.en}
+                                            </button>
+                                        ))}
+                                    </div>
+                                </div>
+
+                                {/* Custom values */}
+                                <div className="mb-3">
+                                    <label className="block text-sm text-gray-300 mb-2">{lang === 'zh' ? '自訂風況' : 'Custom Values'}</label>
+                                    <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                                        <div>
+                                            <label className="text-xs text-gray-500">{lang === 'zh' ? '風速 (m/s)' : 'Wind Speed (m/s)'}</label>
+                                            <input type="number" step="0.5" min="0" max="40" value={customWind.speed}
+                                                onChange={e => setCustomWind(p => ({...p, speed: e.target.value}))}
+                                                className="mt-1 w-full bg-gray-700 border border-gray-600 rounded px-2 py-1.5 text-sm text-white" />
+                                        </div>
+                                        <div>
+                                            <label className="text-xs text-gray-500">{lang === 'zh' ? '風向 (°)' : 'Direction (°)'}</label>
+                                            <input type="number" step="5" min="0" max="360" value={customWind.direction}
+                                                onChange={e => setCustomWind(p => ({...p, direction: e.target.value}))}
+                                                className="mt-1 w-full bg-gray-700 border border-gray-600 rounded px-2 py-1.5 text-sm text-white" />
+                                        </div>
+                                        <div>
+                                            <label className="text-xs text-gray-500">{lang === 'zh' ? '溫度 (°C)' : 'Temp (°C)'}</label>
+                                            <input type="number" step="1" min="-10" max="45" value={customWind.temp}
+                                                onChange={e => setCustomWind(p => ({...p, temp: e.target.value}))}
+                                                className="mt-1 w-full bg-gray-700 border border-gray-600 rounded px-2 py-1.5 text-sm text-white" />
+                                        </div>
+                                        <div>
+                                            <label className="text-xs text-gray-500">{lang === 'zh' ? '湍流度' : 'Turbulence'}</label>
+                                            <input type="number" step="0.05" min="0" max="0.5" value={customWind.turbulence}
+                                                onChange={e => setCustomWind(p => ({...p, turbulence: e.target.value}))}
+                                                className="mt-1 w-full bg-gray-700 border border-gray-600 rounded px-2 py-1.5 text-sm text-white" />
+                                        </div>
+                                    </div>
+                                    <button onClick={handleSetCustomWind}
+                                        className="mt-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold px-4 py-1.5 rounded transition-colors">
+                                        {lang === 'zh' ? '套用自訂風況' : 'Apply Custom Wind'}
+                                    </button>
+                                </div>
+
+                                {windMsg && <div className="text-sm text-cyan-300 bg-cyan-900/30 px-3 py-1 rounded mt-2">{windMsg}</div>}
+
+                                <p className="text-xs text-gray-500 mt-2">
+                                    {lang === 'zh'
+                                        ? '設定風況後，物理模型會自動計算對應的功率、轉速、溫度、振動等所有 SCADA 數據。選「自動」回到日變化模式。'
+                                        : 'After setting wind conditions, the physics model automatically computes all SCADA outputs. Select "Auto" to return to daily pattern.'}
+                                </p>
                             </div>
                         )}
 

--- a/server/models.py
+++ b/server/models.py
@@ -119,6 +119,15 @@ class SimulationConfig(BaseModel):
     timeStep: float = 1.0
 
 
+class WindOverrideRequest(BaseModel):
+    """Set manual wind conditions. null values keep auto mode."""
+    windSpeed: Optional[float] = None       # m/s (None = auto)
+    windDirection: Optional[float] = None   # deg (None = auto)
+    ambientTemp: Optional[float] = None     # °C (None = auto)
+    turbulence: Optional[float] = None      # 0.0-0.5 (None = keep current)
+    profile: Optional[str] = None           # 'calm','moderate','rated','strong','storm','gusty','ramp_up','ramp_down','auto'
+
+
 class FaultInjectionRequest(BaseModel):
     scenarioId: str
     turbineId: str

--- a/server/routers/config.py
+++ b/server/routers/config.py
@@ -1,5 +1,5 @@
-from fastapi import APIRouter
-from server.models import DataSourceConfig, SimulationConfig, DataSourceMode
+from fastapi import APIRouter, HTTPException
+from server.models import DataSourceConfig, SimulationConfig, DataSourceMode, WindOverrideRequest
 
 router = APIRouter(prefix="/api/config", tags=["config"])
 
@@ -39,3 +39,46 @@ async def set_simulation(config: SimulationConfig):
         "turbineCount": config.turbineCount,
         "baseWindSpeed": config.baseWindSpeed,
     }
+
+
+@router.get("/wind")
+async def get_wind_status():
+    """Get current wind model status (auto/manual, override values)."""
+    b = get_broker()
+    if not b.simulator:
+        raise HTTPException(400, "Simulator not running")
+    return b.simulator.wind_model.get_status()
+
+
+@router.post("/wind")
+async def set_wind(req: WindOverrideRequest):
+    """Set wind conditions manually, or activate a profile.
+
+    Profiles: calm, moderate, rated, strong, storm, gusty, ramp_up, ramp_down, auto
+    Or set individual values: windSpeed, windDirection, ambientTemp, turbulence
+    """
+    b = get_broker()
+    if not b.simulator:
+        raise HTTPException(400, "Simulator not running")
+
+    wm = b.simulator.wind_model
+    if req.profile:
+        wm.set_profile(req.profile)
+    else:
+        wm.set_override(
+            wind_speed=req.windSpeed,
+            wind_direction=req.windDirection,
+            ambient_temp=req.ambientTemp,
+            turbulence=req.turbulence,
+        )
+    return wm.get_status()
+
+
+@router.post("/wind/clear")
+async def clear_wind():
+    """Return to automatic daily pattern wind model."""
+    b = get_broker()
+    if not b.simulator:
+        raise HTTPException(400, "Simulator not running")
+    b.simulator.wind_model.clear_override()
+    return {"status": "ok", "mode": "auto"}

--- a/simulator/engine.py
+++ b/simulator/engine.py
@@ -36,9 +36,6 @@ class WindFarmSimulator:
         self._callbacks: List[Callable] = []
         self._lock = threading.Lock()
 
-        # Ambient temperature model (simple daily cycle)
-        self._base_ambient_temp = 25.0
-
         # Initialize turbines
         for i in range(1, turbine_count + 1):
             tid = f"WT{i:03d}"
@@ -73,7 +70,7 @@ class WindFarmSimulator:
                 now = datetime.now()
                 wind_speed = self.wind_model.get_wind_speed(now)
                 wind_direction = self.wind_model.get_wind_direction(now)
-                ambient_temp = self._get_ambient_temp(now)
+                ambient_temp = self.wind_model.get_ambient_temp(now)
 
                 # Advance fault engine
                 fault_modifiers = self.fault_engine.step(dt=time_step)
@@ -115,13 +112,6 @@ class WindFarmSimulator:
             except Exception as e:
                 print(f"[Simulator] Error: {e}")
                 time.sleep(1)
-
-    def _get_ambient_temp(self, now: datetime) -> float:
-        """Simple daily temperature cycle."""
-        hour = now.hour + now.minute / 60.0
-        # Peak at 14:00, min at 05:00
-        import math
-        return self._base_ambient_temp + 5 * math.sin((hour - 5) * math.pi / 12)
 
     @staticmethod
     def _scada_to_output(tid: str, timestamp: datetime,

--- a/wind_model.py
+++ b/wind_model.py
@@ -1,49 +1,155 @@
 # wind_turbine_simulator/wind_model.py
 import numpy as np
 from datetime import datetime
+from typing import Optional
 
 
 class WindEnvironmentModel:
-    """風場環境模型"""
-    
+    """風場環境模型 — 支援自動日變化或手動覆寫模式"""
+
     def __init__(self):
         self.base_pattern = self._create_daily_pattern()
         self.turbulence_intensity = 0.1
-        
+        self.base_ambient_temp = 25.0
+
+        # ── Manual override (None = auto mode) ──
+        self._override_wind_speed: Optional[float] = None
+        self._override_wind_direction: Optional[float] = None
+        self._override_ambient_temp: Optional[float] = None
+
+        # ── Wind event profiles ──
+        self._active_profile: Optional[str] = None
+        self._profile_start_time: Optional[datetime] = None
+
+    # ─── Override control ──────────────────────────────────────────────
+
+    def set_override(self, wind_speed: Optional[float] = None,
+                     wind_direction: Optional[float] = None,
+                     ambient_temp: Optional[float] = None,
+                     turbulence: Optional[float] = None):
+        """Set manual wind conditions. Pass None to keep auto mode for that parameter."""
+        self._override_wind_speed = wind_speed
+        self._override_wind_direction = wind_direction
+        self._override_ambient_temp = ambient_temp
+        if turbulence is not None:
+            self.turbulence_intensity = turbulence
+        self._active_profile = "manual" if any(
+            v is not None for v in [wind_speed, wind_direction, ambient_temp]
+        ) else None
+
+    def clear_override(self):
+        """Return to automatic daily pattern mode."""
+        self._override_wind_speed = None
+        self._override_wind_direction = None
+        self._override_ambient_temp = None
+        self._active_profile = None
+
+    def set_profile(self, profile: str):
+        """
+        Activate a predefined wind scenario profile.
+
+        Profiles:
+          'calm'        — 2 m/s, low turbulence (below cut-in, turbines idle)
+          'moderate'    — 8 m/s, normal turbulence (partial load)
+          'rated'       — 12 m/s, turbines at rated power
+          'strong'      — 18 m/s, pitch regulation active
+          'storm'       — 26 m/s, above cut-out, emergency shutdown
+          'gusty'       — 10 m/s base with high turbulence (0.3)
+          'ramp_up'     — gradual increase 3→15 m/s over time
+          'ramp_down'   — gradual decrease 15→3 m/s over time
+          'auto'        — return to daily pattern
+        """
+        profiles = {
+            'calm':     (2.0, 270, 20.0, 0.05),
+            'moderate': (8.0, 270, 25.0, 0.10),
+            'rated':    (12.0, 270, 25.0, 0.10),
+            'strong':   (18.0, 285, 22.0, 0.12),
+            'storm':    (26.0, 300, 18.0, 0.20),
+            'gusty':    (10.0, 260, 25.0, 0.30),
+        }
+
+        if profile == 'auto':
+            self.clear_override()
+            return
+
+        if profile in ('ramp_up', 'ramp_down'):
+            self._active_profile = profile
+            self._profile_start_time = datetime.now()
+            self._override_wind_direction = 270.0
+            self._override_ambient_temp = 25.0
+            return
+
+        if profile in profiles:
+            ws, wd, temp, turb = profiles[profile]
+            self.set_override(ws, wd, temp, turb)
+            self._active_profile = profile
+
+    def get_status(self) -> dict:
+        """Return current wind model status for API."""
+        return {
+            "mode": "manual" if self._active_profile else "auto",
+            "profile": self._active_profile,
+            "override_wind_speed": self._override_wind_speed,
+            "override_wind_direction": self._override_wind_direction,
+            "override_ambient_temp": self._override_ambient_temp,
+            "turbulence_intensity": self.turbulence_intensity,
+        }
+
+    # ─── Core getters ──────────────────────────────────────────────────
+
+    def get_wind_speed(self, timestamp: datetime) -> float:
+        """獲取指定時間的風速（含覆寫邏輯）"""
+        # Ramp profiles
+        if self._active_profile == 'ramp_up' and self._profile_start_time:
+            elapsed = (timestamp - self._profile_start_time).total_seconds()
+            base = 3.0 + min(12.0, elapsed / 60.0 * 2.0)  # +2 m/s per minute
+        elif self._active_profile == 'ramp_down' and self._profile_start_time:
+            elapsed = (timestamp - self._profile_start_time).total_seconds()
+            base = max(3.0, 15.0 - elapsed / 60.0 * 2.0)
+        elif self._override_wind_speed is not None:
+            base = self._override_wind_speed
+        else:
+            # Auto: daily pattern
+            hour_of_day = timestamp.hour + timestamp.minute / 60
+            index = int(hour_of_day * 10)
+            base = self.base_pattern[index % len(self.base_pattern)]
+
+        # Add turbulence
+        turbulence = np.random.normal(0, max(0.1, base * self.turbulence_intensity))
+        return max(0, base + turbulence)
+
+    def get_wind_direction(self, timestamp: datetime) -> float:
+        """獲取風向"""
+        if self._override_wind_direction is not None:
+            # Small random variation around override value
+            return (self._override_wind_direction + np.random.normal(0, 3)) % 360
+
+        # Auto: slow drift
+        base_direction = 270
+        variation = 30 * np.sin(timestamp.hour * np.pi / 12)
+        return (base_direction + variation) % 360
+
+    def get_ambient_temp(self, timestamp: datetime) -> float:
+        """獲取環境溫度"""
+        if self._override_ambient_temp is not None:
+            return self._override_ambient_temp + np.random.normal(0, 0.3)
+
+        # Auto: daily cycle
+        import math
+        hour = timestamp.hour + timestamp.minute / 60.0
+        return self.base_ambient_temp + 5 * math.sin((hour - 5) * math.pi / 12)
+
     def _create_daily_pattern(self):
         """創建日常風速模式"""
         hours = np.arange(0, 24, 0.1)
         pattern = np.zeros_like(hours)
-        
         for i, hour in enumerate(hours):
-            if 0 <= hour < 6:  # 凌晨
+            if 0 <= hour < 6:
                 pattern[i] = 4 + np.sin(hour * np.pi / 6)
-            elif 6 <= hour < 12:  # 上午
+            elif 6 <= hour < 12:
                 pattern[i] = 3 + 4 * (hour - 6) / 6
-            elif 12 <= hour < 18:  # 下午
+            elif 12 <= hour < 18:
                 pattern[i] = 7 + 3 * np.sin((hour - 12) * np.pi / 6)
-            else:  # 晚上
+            else:
                 pattern[i] = 4 + 2 * np.cos((hour - 18) * np.pi / 6)
-        
         return pattern
-    
-    def get_wind_speed(self, timestamp: datetime) -> float:
-        """
-        獲取指定時間的風速
-        包含基本模式和湍流
-        """
-        hour_of_day = timestamp.hour + timestamp.minute / 60
-        index = int(hour_of_day * 10)
-        base_speed = self.base_pattern[index % len(self.base_pattern)]
-        
-        # 添加湍流
-        turbulence = np.random.normal(0, base_speed * self.turbulence_intensity)
-        
-        return max(0, base_speed + turbulence)
-    
-    def get_wind_direction(self, timestamp: datetime) -> float:
-        """獲取風向"""
-        # 簡化模型：風向緩慢變化
-        base_direction = 270  # 西風
-        variation = 30 * np.sin(timestamp.hour * np.pi / 12)
-        return (base_direction + variation) % 360


### PR DESCRIPTION
- WindEnvironmentModel: manual override mode for wind speed, direction, ambient temp, turbulence; 9 preset profiles (calm/moderate/rated/ strong/storm/gusty/ramp_up/ramp_down/auto)
- API: GET/POST /api/config/wind, POST /api/config/wind/clear
- Settings UI: quick profile buttons + custom value inputs with i18n
- Engine uses wind model's ambient temp (removed duplicate method)

https://claude.ai/code/session_01QXekwDWAdCEfjvTwDqYHjd