### PR TITLE
fix: prevent Settings save from resetting wind/control overrides

### DIFF
--- a/frontend/hooks/useSettings.ts
+++ b/frontend/hooks/useSettings.ts
@@ -25,20 +25,26 @@ export const useSettings = () => {
 
     const saveSettings = (newSettings: AppSettings) => {
         try {
+            const prevSettings = settings;
             setSettings(newSettings);
             window.localStorage.setItem(SETTINGS_KEY, JSON.stringify(newSettings));
 
-            // Sync data source with backend
+            // Only sync simulation config if params actually changed
             if (newSettings.dataSource === DataSourceType.SIMULATION) {
-                fetch(`${API_BASE}/api/config/simulation`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        turbineCount: newSettings.simulation.turbineCount,
-                        baseWindSpeed: newSettings.simulation.baseWindSpeed,
-                        turbulenceIntensity: newSettings.simulation.turbulenceIntensity,
-                    }),
-                }).catch(err => console.warn('Failed to sync simulation config:', err.message));
+                const simChanged =
+                    prevSettings.simulation.turbineCount !== newSettings.simulation.turbineCount ||
+                    prevSettings.simulation.turbulenceIntensity !== newSettings.simulation.turbulenceIntensity;
+                if (simChanged) {
+                    fetch(`${API_BASE}/api/config/simulation`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            turbineCount: newSettings.simulation.turbineCount,
+                            baseWindSpeed: newSettings.simulation.baseWindSpeed,
+                            turbulenceIntensity: newSettings.simulation.turbulenceIntensity,
+                        }),
+                    }).catch(err => console.warn('Failed to sync simulation config:', err.message));
+                }
             } else if (newSettings.dataSource === DataSourceType.OPC_DA) {
                 fetch(`${API_BASE}/api/config/datasource`, {
                     method: 'POST',

--- a/server/routers/config.py
+++ b/server/routers/config.py
@@ -30,14 +30,29 @@ async def set_datasource(config: DataSourceConfig):
 
 @router.post("/simulation")
 async def set_simulation(config: SimulationConfig):
-    """Update simulation parameters and restart simulator."""
+    """Update simulation parameters. Only restarts if turbine count changed."""
     b = get_broker()
+
+    # Only restart if turbine count actually changed
+    current_count = len(b.turbine_ids) if b.simulator else 0
+    if b.simulator and b.simulator.is_running and config.turbineCount == current_count:
+        # Just update wind model parameters without restarting
+        b.simulator.wind_model.turbulence_intensity = config.turbulenceIntensity
+        return {
+            "status": "ok",
+            "turbineCount": config.turbineCount,
+            "baseWindSpeed": config.baseWindSpeed,
+            "restarted": False,
+        }
+
+    # Turbine count changed — full restart required
     ds_config = DataSourceConfig(mode=DataSourceMode.SIMULATION)
     b.switch_mode(ds_config, config)
     return {
         "status": "ok",
         "turbineCount": config.turbineCount,
         "baseWindSpeed": config.baseWindSpeed,
+        "restarted": True,
     }
 
 


### PR DESCRIPTION
- Backend: POST /api/config/simulation only restarts simulator if turbine count actually changed; otherwise just updates turbulence
- Frontend: useSettings only syncs simulation config when params actually changed, preventing unnecessary simulator restarts

Previously, every Settings Save would recreate the simulator, losing wind profile, curtailment, and operator control settings.

https://claude.ai/code/session_01QXekwDWAdCEfjvTwDqYHjd