### PR TITLE
Add tabbed subsystem view and farm-wide trend chart to turbine detail

### DIFF
--- a/frontend/components/FarmOverview.tsx
+++ b/frontend/components/FarmOverview.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo } from 'react';
 import { type TurbineData, TurbineStatus, type AppSettings, DataSourceType } from '../types';
 import StatusIndicator from './StatusIndicator';
 import { WindTurbineIcon } from './icons';
+import FarmTrendChart from './FarmTrendChart';
 
 interface FarmOverviewProps {
   turbines: TurbineData[];
@@ -109,27 +110,33 @@ const SummaryView: React.FC<{ turbines: TurbineData[]; onSelect: (t: TurbineData
         </div>
       </div>
 
-      {/* Compact turbine grid */}
-      <div className="flex-1 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-7 gap-2">
-        {turbines.map(t => (
-          <div key={t.id} onClick={() => onSelect(t)}
-            className={`rounded-md p-2 border cursor-pointer transition-all hover:scale-105 ${
-              t.status === TurbineStatus.FAULT ? 'border-red-500/50 bg-red-500/10' :
-              t.status === TurbineStatus.OPERATING ? 'border-green-500/30 bg-gray-800/50' :
-              'border-gray-600/30 bg-gray-800/30'
-            }`}>
-            <div className="flex justify-between items-center mb-1">
-              <span className="text-xs font-bold text-white">{t.name}</span>
-              <span className={`w-2 h-2 rounded-full ${
-                t.status === TurbineStatus.OPERATING ? 'bg-green-400' :
-                t.status === TurbineStatus.FAULT ? 'bg-red-400 animate-pulse' :
-                'bg-yellow-400'
-              }`} />
+      {/* Right column: trend chart + compact grid */}
+      <div className="flex-1 space-y-4">
+        {/* Farm-wide trend chart */}
+        <FarmTrendChart turbines={turbines} lang={lang} />
+
+        {/* Compact turbine grid */}
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-7 gap-2">
+          {turbines.map(t => (
+            <div key={t.id} onClick={() => onSelect(t)}
+              className={`rounded-md p-2 border cursor-pointer transition-all hover:scale-105 ${
+                t.status === TurbineStatus.FAULT ? 'border-red-500/50 bg-red-500/10' :
+                t.status === TurbineStatus.OPERATING ? 'border-green-500/30 bg-gray-800/50' :
+                'border-gray-600/30 bg-gray-800/30'
+              }`}>
+              <div className="flex justify-between items-center mb-1">
+                <span className="text-xs font-bold text-white">{t.name}</span>
+                <span className={`w-2 h-2 rounded-full ${
+                  t.status === TurbineStatus.OPERATING ? 'bg-green-400' :
+                  t.status === TurbineStatus.FAULT ? 'bg-red-400 animate-pulse' :
+                  'bg-yellow-400'
+                }`} />
+              </div>
+              <div className="text-lg font-orbitron font-bold text-white">{t.powerOutput.toFixed(1)}<span className="text-xs text-gray-400 ml-0.5">MW</span></div>
+              <div className="text-xs text-gray-500">{t.windSpeed.toFixed(1)} m/s</div>
             </div>
-            <div className="text-lg font-orbitron font-bold text-white">{t.powerOutput.toFixed(1)}<span className="text-xs text-gray-400 ml-0.5">MW</span></div>
-            <div className="text-xs text-gray-500">{t.windSpeed.toFixed(1)} m/s</div>
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/frontend/components/FarmTrendChart.tsx
+++ b/frontend/components/FarmTrendChart.tsx
@@ -1,0 +1,115 @@
+import React, { useRef, useEffect, useState } from 'react';
+import { LineChart, Line, XAxis, YAxis, ResponsiveContainer, Tooltip, Legend } from 'recharts';
+import { type TurbineData } from '../types';
+
+interface FarmTrendChartProps {
+  turbines: TurbineData[];
+  lang?: 'en' | 'zh';
+}
+
+interface FarmDataPoint {
+  time: number;
+  totalPower: number;
+  avgWindSpeed: number;
+}
+
+const MAX_POINTS = 120; // ~4 minutes at 2s intervals
+
+const FarmTrendChart: React.FC<FarmTrendChartProps> = ({ turbines, lang = 'zh' }) => {
+  const [data, setData] = useState<FarmDataPoint[]>([]);
+  const lastUpdate = useRef(0);
+
+  useEffect(() => {
+    if (!turbines.length) return;
+    const now = Date.now();
+    // Throttle to ~2s intervals to match WS refresh
+    if (now - lastUpdate.current < 1800) return;
+    lastUpdate.current = now;
+
+    const totalPower = turbines.reduce((s, t) => s + t.powerOutput, 0);
+    const avgWindSpeed = turbines.reduce((s, t) => s + t.windSpeed, 0) / turbines.length;
+
+    setData(prev => {
+      const next = [...prev, { time: now, totalPower: +totalPower.toFixed(2), avgWindSpeed: +avgWindSpeed.toFixed(1) }];
+      return next.length > MAX_POINTS ? next.slice(-MAX_POINTS) : next;
+    });
+  }, [turbines]);
+
+  const u = (en: string, zh: string) => lang === 'zh' ? zh : en;
+
+  return (
+    <div className="bg-gray-800/50 rounded-lg p-4 border border-cyan-500/20">
+      <h4 className="text-sm font-semibold text-cyan-400 mb-3 uppercase tracking-wider">
+        {u('Farm Power & Wind Trend', '全風場發電量與風速趨勢')}
+      </h4>
+      <div className="bg-gray-900/50 rounded p-2">
+        <ResponsiveContainer width="100%" height={220}>
+          <LineChart data={data} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
+            <XAxis
+              dataKey="time"
+              tickFormatter={(t) => t ? new Date(t).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' }) : ''}
+              stroke="#6b7280"
+              fontSize={10}
+              axisLine={false}
+              tickLine={false}
+            />
+            <YAxis
+              yAxisId="power"
+              stroke="#22d3ee"
+              fontSize={10}
+              axisLine={false}
+              tickLine={false}
+              tickFormatter={(v) => `${v}`}
+              label={{ value: 'MW', angle: -90, position: 'insideLeft', style: { fill: '#22d3ee', fontSize: 10 } }}
+            />
+            <YAxis
+              yAxisId="wind"
+              orientation="right"
+              stroke="#f59e0b"
+              fontSize={10}
+              axisLine={false}
+              tickLine={false}
+              tickFormatter={(v) => `${v}`}
+              label={{ value: 'm/s', angle: 90, position: 'insideRight', style: { fill: '#f59e0b', fontSize: 10 } }}
+            />
+            <Tooltip
+              contentStyle={{ backgroundColor: 'rgba(17,24,39,0.95)', border: '1px solid #374151', borderRadius: '0.5rem', color: '#e5e7eb' }}
+              labelFormatter={(t) => t ? new Date(t).toLocaleTimeString() : ''}
+              formatter={(value: number, name: string) => {
+                if (name === 'totalPower') return [`${value.toFixed(2)} MW`, u('Total Power', '總發電量')];
+                return [`${value.toFixed(1)} m/s`, u('Avg Wind Speed', '平均風速')];
+              }}
+            />
+            <Legend
+              formatter={(value) => {
+                if (value === 'totalPower') return u('Total Power (MW)', '總發電量 (MW)');
+                return u('Avg Wind Speed (m/s)', '平均風速 (m/s)');
+              }}
+              wrapperStyle={{ fontSize: '11px' }}
+            />
+            <Line
+              yAxisId="power"
+              type="monotone"
+              dataKey="totalPower"
+              stroke="#22d3ee"
+              strokeWidth={2}
+              dot={false}
+              isAnimationActive={false}
+            />
+            <Line
+              yAxisId="wind"
+              type="monotone"
+              dataKey="avgWindSpeed"
+              stroke="#f59e0b"
+              strokeWidth={2}
+              dot={false}
+              isAnimationActive={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+};
+
+export default FarmTrendChart;

--- a/frontend/components/TurbineDetail.tsx
+++ b/frontend/components/TurbineDetail.tsx
@@ -198,10 +198,23 @@ const OperatorControlPanel: React.FC<{ turbineId: string; lang: string }> = ({ t
   );
 };
 
+type DetailTab = 'overview' | 'generator' | 'pitch' | 'converter' | 'nacelle' | 'yaw' | 'grid';
+
+const DETAIL_TABS: { id: DetailTab; label_en: string; label_zh: string; color: string; preset?: string }[] = [
+  { id: 'overview', label_en: 'Overview', label_zh: '總覽', color: 'cyan' },
+  { id: 'generator', label_en: 'Generator', label_zh: '發電機', color: 'cyan', preset: 'power' },
+  { id: 'pitch', label_en: 'Pitch/Rotor', label_zh: '旋角系統', color: 'green', preset: 'pitch' },
+  { id: 'converter', label_en: 'Converter', label_zh: '變頻器', color: 'purple', preset: 'converter' },
+  { id: 'nacelle', label_en: 'Nacelle', label_zh: '機艙', color: 'yellow', preset: 'vibration' },
+  { id: 'yaw', label_en: 'Yaw', label_zh: '轉向系統', color: 'blue', preset: 'yaw' },
+  { id: 'grid', label_en: 'Grid/Met', label_zh: '電網/氣象', color: 'orange', preset: 'temperature' },
+];
+
 const TurbineDetail: React.FC<TurbineDetailProps> = ({ turbine, onBack, onDispatch, activeWorkOrder, lang = 'zh' }) => {
     const [isAnalyzing, setIsAnalyzing] = useState(false);
     const [analysisResult, setAnalysisResult] = useState<string | null>(null);
     const [analysisError, setAnalysisError] = useState<string | null>(null);
+    const [activeTab, setActiveTab] = useState<DetailTab>('overview');
 
     useEffect(() => {
         if(turbine.status === TurbineStatus.FAULT && !analysisResult && !isAnalyzing) {
@@ -236,26 +249,149 @@ const TurbineDetail: React.FC<TurbineDetailProps> = ({ turbine, onBack, onDispat
     const turStateLabel = TUR_STATE_LABELS[turbine.turState || 0];
     const turStateText = turStateLabel ? (lang === 'zh' ? turStateLabel.zh : turStateLabel.en) : `State ${turbine.turState}`;
     const hasFaults = turbine.activeFaults && turbine.activeFaults.length > 0;
+    const turbineApiId = `WT${String(turbine.id).padStart(3, '0')}`;
+    const u = (en: string, zh: string) => lang === 'zh' ? zh : en;
+
+    const renderTabContent = () => {
+      switch (activeTab) {
+        case 'overview':
+          return (
+            <>
+              {/* Gauges row */}
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
+                <Gauge value={turbine.powerOutput} maxValue={5} label={u('Power Output', '發電功率')} unit="MW" />
+                <Gauge value={turbine.rotorSpeed} maxValue={15} label={u('Rotor Speed', '葉輪轉速')} unit="RPM" />
+                <Gauge value={turbine.windSpeed} maxValue={25} label={u('Wind Speed', '風速')} unit="m/s" />
+                <div className="bg-gray-800/50 p-4 rounded-lg flex flex-col justify-center">
+                   <h3 className="text-gray-400 text-sm mb-2 text-center">{u('Power Trend', '功率趨勢')}</h3>
+                   <MiniTrendChart data={turbine.history} />
+                </div>
+              </div>
+              {/* Trend Chart - prominently placed in overview */}
+              <div className="mb-6">
+                <TrendChartPanel turbineId={turbineApiId} lang={lang} />
+              </div>
+            </>
+          );
+
+        case 'generator':
+          return (
+            <div className="space-y-6">
+              <SubsystemPanel title={u('WGEN Generator', 'WGEN 發電機')}>
+                <DataRow label={u('Power', '功率')} value={`${fmt(turbine.genPower)} kW`} />
+                <DataRow label={u('Speed', '轉速')} value={`${fmt(turbine.genSpeed, 0)} RPM`} />
+                <DataRow label={u('Voltage', '電壓')} value={`${fmt(turbine.voltage, 0)} V`} />
+                <DataRow label={u('Current', '電流')} value={`${fmt(turbine.current, 0)} A`} />
+                <DataRow label={u('Stator Temp', '定子溫度')} value={`${fmt(turbine.genStatorTemp1)}°C`}
+                  warn={(turbine.genStatorTemp1 || 0) > 100} alert={(turbine.genStatorTemp1 || 0) > 130} />
+                <DataRow label={u('Air Gap Temp', '氣隙溫度')} value={`${fmt(turbine.genAirTemp1)}°C`}
+                  warn={(turbine.genAirTemp1 || 0) > 80} />
+                <DataRow label={u('Bearing Temp', '軸承溫度')} value={`${fmt(turbine.genBearingTemp1)}°C`}
+                  warn={(turbine.genBearingTemp1 || 0) > 70} alert={(turbine.genBearingTemp1 || 0) > 90} />
+              </SubsystemPanel>
+              <TrendChartPanel turbineId={turbineApiId} lang={lang} />
+            </div>
+          );
+
+        case 'pitch':
+          return (
+            <div className="space-y-6">
+              <SubsystemPanel title={u('WROT Rotor/Pitch', 'WROT 葉輪/旋角')} color="green">
+                <DataRow label={u('Rotor RPM', '葉輪轉速')} value={`${fmt(turbine.rotorSpeed, 2)} RPM`} />
+                <DataRow label={u('Blade 1', '葉片1角度')} value={`${fmt(turbine.bladeAngle1)}°`} />
+                <DataRow label={u('Blade 2', '葉片2角度')} value={`${fmt(turbine.bladeAngle2)}°`} />
+                <DataRow label={u('Blade 3', '葉片3角度')} value={`${fmt(turbine.bladeAngle3)}°`} />
+                <DataRow label={u('Rotor Temp', '轉子溫度')} value={`${fmt(turbine.rotorTemp)}°C`} />
+                <DataRow label={u('Hub Cab Temp', '輪毂櫃溫')} value={`${fmt(turbine.hubCabinetTemp)}°C`} />
+                <DataRow label={u('Locked/Brake', '鎖固/剎車')}
+                  value={`${turbine.rotorLocked ? 'Locked' : '-'} / ${turbine.brakeActive ? 'Active' : '-'}`} />
+              </SubsystemPanel>
+              <TrendChartPanel turbineId={turbineApiId} lang={lang} />
+            </div>
+          );
+
+        case 'converter':
+          return (
+            <div className="space-y-6">
+              <SubsystemPanel title={u('WCNV Converter', 'WCNV 變頻器')} color="purple">
+                <DataRow label={u('Gen Power', '發電機功率')} value={`${fmt(turbine.cnvGenPower)} kW`} />
+                <DataRow label={u('Grid Power', '電網功率')} value={`${fmt(turbine.cnvGridPower)} kW`} />
+                <DataRow label={u('Frequency', '頻率')} value={`${fmt(turbine.cnvGenFreq, 2)} Hz`} />
+                <DataRow label={u('DC Voltage', 'DC電壓')} value={`${fmt(turbine.cnvDcVoltage, 0)} V`} />
+                <DataRow label={u('Cabinet Temp', '控制櫃溫度')} value={`${fmt(turbine.cnvCabinetTemp)}°C`}
+                  warn={(turbine.cnvCabinetTemp || 0) > 45} />
+                <DataRow label={u('IGCT Water Temp', 'IGCT水溫')} value={`${fmt(turbine.igctWaterTemp)}°C`}
+                  warn={(turbine.igctWaterTemp || 0) > 40} />
+                <DataRow label={u('IGCT Pressure', 'IGCT水壓')} value={`${fmt(turbine.igctWaterPres1)} / ${fmt(turbine.igctWaterPres2)} bar`} />
+              </SubsystemPanel>
+              <TrendChartPanel turbineId={turbineApiId} lang={lang} />
+            </div>
+          );
+
+        case 'nacelle':
+          return (
+            <div className="space-y-6">
+              <SubsystemPanel title={u('WNAC Nacelle', 'WNAC 機艙')} color="yellow">
+                <DataRow label={u('Nacelle Temp', '機艙溫度')} value={`${fmt(turbine.nacelleTemp)}°C`} />
+                <DataRow label={u('Cabinet Temp', '控制櫃溫度')} value={`${fmt(turbine.nacelleCabTemp)}°C`} />
+                <DataRow label={u('Vibration X', 'X方向振動')} value={`${fmt(turbine.vibrationX, 2)} mm/s`}
+                  warn={(turbine.vibrationX || 0) > 4} alert={(turbine.vibrationX || 0) > 8} />
+                <DataRow label={u('Vibration Y', 'Y方向振動')} value={`${fmt(turbine.vibrationY, 2)} mm/s`}
+                  warn={(turbine.vibrationY || 0) > 4} alert={(turbine.vibrationY || 0) > 8} />
+              </SubsystemPanel>
+              <TrendChartPanel turbineId={turbineApiId} lang={lang} />
+            </div>
+          );
+
+        case 'yaw':
+          return (
+            <div className="space-y-6">
+              <SubsystemPanel title={u('WYAW Yaw System', 'WYAW 轉向系統')} color="blue">
+                <DataRow label={u('Yaw Error (5s)', '風向誤差(5s)')} value={`${fmt(turbine.yawError)}°`}
+                  warn={Math.abs(turbine.yawError || 0) > 10} />
+                <DataRow label={u('Brake Pressure', '剎車液壓')} value={`${fmt(turbine.yawBrakePressure, 0)} bar`} />
+                <DataRow label={u('Cable Windup', '纜線圈數')} value={`${fmt(turbine.cableWindup, 2)} turns`}
+                  warn={Math.abs(turbine.cableWindup || 0) > 3} />
+              </SubsystemPanel>
+              <TrendChartPanel turbineId={turbineApiId} lang={lang} />
+            </div>
+          );
+
+        case 'grid':
+          return (
+            <div className="space-y-6">
+              <SubsystemPanel title={u('WGDC/WMET Grid/Met', 'WGDC/WMET 電網/氣象')} color="orange">
+                <DataRow label={u('Transformer Temp', '變壓器溫度')} value={`${fmt(turbine.transformerTemp)}°C`}
+                  warn={(turbine.transformerTemp || 0) > 80} />
+                <DataRow label={u('Wind Speed', '風速')} value={`${fmt(turbine.windSpeed)} m/s`} />
+                <DataRow label={u('Wind Dir', '風向')} value={`${fmt(turbine.windDirection, 0)}°`} />
+                <DataRow label={u('Outside Temp', '室外溫度')} value={`${fmt(turbine.outsideTemp)}°C`} />
+              </SubsystemPanel>
+              <TrendChartPanel turbineId={turbineApiId} lang={lang} />
+            </div>
+          );
+      }
+    };
 
   return (
     <div>
         <button onClick={onBack} className="flex items-center space-x-2 text-cyan-400 hover:text-cyan-300 mb-6 transition-colors">
             <BackIcon />
-            <span>{lang === 'zh' ? '返回風場總覽' : 'Back to Farm Overview'}</span>
+            <span>{u('Back to Farm Overview', '返回風場總覽')}</span>
         </button>
 
       {/* Header */}
-      <div className="bg-gray-800/50 rounded-lg p-6 mb-6">
+      <div className="bg-gray-800/50 rounded-lg p-6 mb-4">
         <div className="flex flex-col sm:flex-row justify-between sm:items-center">
             <div>
               <h2 className="text-4xl font-bold font-orbitron text-white">{turbine.name}</h2>
               <div className="flex items-center space-x-3 mt-2 text-sm">
                 <span className="text-gray-400">TurState: <span className="text-white font-semibold">{turbine.turState} - {turStateText}</span></span>
                 {turbine.outsideTemp != null && (
-                  <span className="text-gray-400">{lang === 'zh' ? '室外' : 'Outdoor'}: <span className="text-white">{fmt(turbine.outsideTemp)}°C</span></span>
+                  <span className="text-gray-400">{u('Outdoor', '室外')}: <span className="text-white">{fmt(turbine.outsideTemp)}°C</span></span>
                 )}
                 {turbine.windDirection != null && (
-                  <span className="text-gray-400">{lang === 'zh' ? '風向' : 'Wind Dir'}: <span className="text-white">{fmt(turbine.windDirection, 0)}°</span></span>
+                  <span className="text-gray-400">{u('Wind Dir', '風向')}: <span className="text-white">{fmt(turbine.windDirection, 0)}°</span></span>
                 )}
               </div>
             </div>
@@ -265,7 +401,7 @@ const TurbineDetail: React.FC<TurbineDetailProps> = ({ turbine, onBack, onDispat
 
       {/* Fault alerts */}
       {hasFaults && (
-        <div className="mb-6 space-y-2">
+        <div className="mb-4 space-y-2">
           {turbine.activeFaults!.map((f, i) => (
             <FaultBadge key={i} fault={f} lang={lang} />
           ))}
@@ -273,101 +409,42 @@ const TurbineDetail: React.FC<TurbineDetailProps> = ({ turbine, onBack, onDispat
       )}
 
       {/* Operator Control Panel */}
-      <OperatorControlPanel turbineId={`WT${String(turbine.id).padStart(3, '0')}`} lang={lang} />
+      <OperatorControlPanel turbineId={turbineApiId} lang={lang} />
 
-      {/* Gauges row */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
-        <Gauge value={turbine.powerOutput} maxValue={5} label={lang === 'zh' ? '發電功率' : 'Power Output'} unit="MW" />
-        <Gauge value={turbine.rotorSpeed} maxValue={15} label={lang === 'zh' ? '葉輪轉速' : 'Rotor Speed'} unit="RPM" />
-        <Gauge value={turbine.windSpeed} maxValue={25} label={lang === 'zh' ? '風速' : 'Wind Speed'} unit="m/s" />
-        <div className="bg-gray-800/50 p-4 rounded-lg flex flex-col justify-center">
-           <h3 className="text-gray-400 text-sm mb-2 text-center">{lang === 'zh' ? '功率趨勢' : 'Power Trend'}</h3>
-           <MiniTrendChart data={turbine.history} />
-        </div>
+      {/* Tab Navigation */}
+      <div className="flex overflow-x-auto gap-1 mb-6 bg-gray-800/50 rounded-lg p-1 border border-gray-700">
+        {DETAIL_TABS.map(tab => {
+          const activeStyles: Record<string, string> = {
+            cyan:   'bg-cyan-600/30 text-cyan-300 border-cyan-500/50',
+            green:  'bg-green-600/30 text-green-300 border-green-500/50',
+            purple: 'bg-purple-600/30 text-purple-300 border-purple-500/50',
+            yellow: 'bg-yellow-600/30 text-yellow-300 border-yellow-500/50',
+            blue:   'bg-blue-600/30 text-blue-300 border-blue-500/50',
+            orange: 'bg-orange-600/30 text-orange-300 border-orange-500/50',
+          };
+          return (
+            <button key={tab.id} onClick={() => setActiveTab(tab.id)}
+              className={`flex-shrink-0 px-4 py-2 text-sm font-medium rounded-md transition-colors border ${
+                activeTab === tab.id
+                  ? activeStyles[tab.color] || activeStyles.cyan
+                  : 'text-gray-400 hover:text-white hover:bg-gray-700/50 border-transparent'
+              }`}>
+              {lang === 'zh' ? tab.label_zh : tab.label_en}
+            </button>
+          );
+        })}
       </div>
 
-      {/* SCADA subsystem panels */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
-        {/* Generator */}
-        <SubsystemPanel title={lang === 'zh' ? 'WGEN 發電機' : 'WGEN Generator'}>
-          <DataRow label={lang === 'zh' ? '功率' : 'Power'} value={`${fmt(turbine.genPower)} kW`} />
-          <DataRow label={lang === 'zh' ? '轉速' : 'Speed'} value={`${fmt(turbine.genSpeed, 0)} RPM`} />
-          <DataRow label={lang === 'zh' ? '電壓' : 'Voltage'} value={`${fmt(turbine.voltage, 0)} V`} />
-          <DataRow label={lang === 'zh' ? '電流' : 'Current'} value={`${fmt(turbine.current, 0)} A`} />
-          <DataRow label={lang === 'zh' ? '定子溫度' : 'Stator Temp'} value={`${fmt(turbine.genStatorTemp1)}°C`}
-            warn={(turbine.genStatorTemp1 || 0) > 100} alert={(turbine.genStatorTemp1 || 0) > 130} />
-          <DataRow label={lang === 'zh' ? '氣隙溫度' : 'Air Gap Temp'} value={`${fmt(turbine.genAirTemp1)}°C`}
-            warn={(turbine.genAirTemp1 || 0) > 80} />
-          <DataRow label={lang === 'zh' ? '軸承溫度' : 'Bearing Temp'} value={`${fmt(turbine.genBearingTemp1)}°C`}
-            warn={(turbine.genBearingTemp1 || 0) > 70} alert={(turbine.genBearingTemp1 || 0) > 90} />
-        </SubsystemPanel>
+      {/* Tab Content */}
+      {renderTabContent()}
 
-        {/* Rotor / Pitch */}
-        <SubsystemPanel title={lang === 'zh' ? 'WROT 葉輪/旋角' : 'WROT Rotor/Pitch'} color="green">
-          <DataRow label={lang === 'zh' ? '葉輪轉速' : 'Rotor RPM'} value={`${fmt(turbine.rotorSpeed, 2)} RPM`} />
-          <DataRow label={lang === 'zh' ? '葉片1角度' : 'Blade 1'} value={`${fmt(turbine.bladeAngle1)}°`} />
-          <DataRow label={lang === 'zh' ? '葉片2角度' : 'Blade 2'} value={`${fmt(turbine.bladeAngle2)}°`} />
-          <DataRow label={lang === 'zh' ? '葉片3角度' : 'Blade 3'} value={`${fmt(turbine.bladeAngle3)}°`} />
-          <DataRow label={lang === 'zh' ? '轉子溫度' : 'Rotor Temp'} value={`${fmt(turbine.rotorTemp)}°C`} />
-          <DataRow label={lang === 'zh' ? '輪毂櫃溫' : 'Hub Cab Temp'} value={`${fmt(turbine.hubCabinetTemp)}°C`} />
-          <DataRow label={lang === 'zh' ? '鎖固/剎車' : 'Locked/Brake'}
-            value={`${turbine.rotorLocked ? 'Locked' : '-'} / ${turbine.brakeActive ? 'Active' : '-'}`} />
-        </SubsystemPanel>
-
-        {/* Converter */}
-        <SubsystemPanel title={lang === 'zh' ? 'WCNV 變頻器' : 'WCNV Converter'} color="purple">
-          <DataRow label={lang === 'zh' ? '發電機功率' : 'Gen Power'} value={`${fmt(turbine.cnvGenPower)} kW`} />
-          <DataRow label={lang === 'zh' ? '電網功率' : 'Grid Power'} value={`${fmt(turbine.cnvGridPower)} kW`} />
-          <DataRow label={lang === 'zh' ? '頻率' : 'Frequency'} value={`${fmt(turbine.cnvGenFreq, 2)} Hz`} />
-          <DataRow label={lang === 'zh' ? 'DC電壓' : 'DC Voltage'} value={`${fmt(turbine.cnvDcVoltage, 0)} V`} />
-          <DataRow label={lang === 'zh' ? '控制櫃溫度' : 'Cabinet Temp'} value={`${fmt(turbine.cnvCabinetTemp)}°C`}
-            warn={(turbine.cnvCabinetTemp || 0) > 45} />
-          <DataRow label={lang === 'zh' ? 'IGCT水溫' : 'IGCT Water Temp'} value={`${fmt(turbine.igctWaterTemp)}°C`}
-            warn={(turbine.igctWaterTemp || 0) > 40} />
-          <DataRow label={lang === 'zh' ? 'IGCT水壓' : 'IGCT Pressure'} value={`${fmt(turbine.igctWaterPres1)} / ${fmt(turbine.igctWaterPres2)} bar`} />
-        </SubsystemPanel>
-
-        {/* Nacelle */}
-        <SubsystemPanel title={lang === 'zh' ? 'WNAC 機艙' : 'WNAC Nacelle'} color="yellow">
-          <DataRow label={lang === 'zh' ? '機艙溫度' : 'Nacelle Temp'} value={`${fmt(turbine.nacelleTemp)}°C`} />
-          <DataRow label={lang === 'zh' ? '控制櫃溫度' : 'Cabinet Temp'} value={`${fmt(turbine.nacelleCabTemp)}°C`} />
-          <DataRow label={lang === 'zh' ? 'X方向振動' : 'Vibration X'} value={`${fmt(turbine.vibrationX, 2)} mm/s`}
-            warn={(turbine.vibrationX || 0) > 4} alert={(turbine.vibrationX || 0) > 8} />
-          <DataRow label={lang === 'zh' ? 'Y方向振動' : 'Vibration Y'} value={`${fmt(turbine.vibrationY, 2)} mm/s`}
-            warn={(turbine.vibrationY || 0) > 4} alert={(turbine.vibrationY || 0) > 8} />
-        </SubsystemPanel>
-
-        {/* Yaw */}
-        <SubsystemPanel title={lang === 'zh' ? 'WYAW 轉向系統' : 'WYAW Yaw System'} color="blue">
-          <DataRow label={lang === 'zh' ? '風向誤差(5s)' : 'Yaw Error (5s)'} value={`${fmt(turbine.yawError)}°`}
-            warn={Math.abs(turbine.yawError || 0) > 10} />
-          <DataRow label={lang === 'zh' ? '剎車液壓' : 'Brake Pressure'} value={`${fmt(turbine.yawBrakePressure, 0)} bar`} />
-          <DataRow label={lang === 'zh' ? '纜線圈數' : 'Cable Windup'} value={`${fmt(turbine.cableWindup, 2)} turns`}
-            warn={Math.abs(turbine.cableWindup || 0) > 3} />
-        </SubsystemPanel>
-
-        {/* Grid / Transformer + Met */}
-        <SubsystemPanel title={lang === 'zh' ? 'WGDC/WMET 電網/氣象' : 'WGDC/WMET Grid/Met'} color="orange">
-          <DataRow label={lang === 'zh' ? '變壓器溫度' : 'Transformer Temp'} value={`${fmt(turbine.transformerTemp)}°C`}
-            warn={(turbine.transformerTemp || 0) > 80} />
-          <DataRow label={lang === 'zh' ? '風速' : 'Wind Speed'} value={`${fmt(turbine.windSpeed)} m/s`} />
-          <DataRow label={lang === 'zh' ? '風向' : 'Wind Dir'} value={`${fmt(turbine.windDirection, 0)}°`} />
-          <DataRow label={lang === 'zh' ? '室外溫度' : 'Outside Temp'} value={`${fmt(turbine.outsideTemp)}°C`} />
-        </SubsystemPanel>
-      </div>
-
-      {/* Trend Chart */}
-      <div className="mb-6">
-        <TrendChartPanel turbineId={`WT${String(turbine.id).padStart(3, '0')}`} lang={lang} />
-      </div>
-
-      {/* AI Fault Diagnosis */}
+      {/* AI Fault Diagnosis - always visible when in fault */}
       {turbine.status === TurbineStatus.FAULT && (
          <div className="mt-6 bg-red-900/30 border border-red-500/50 rounded-lg p-6">
             <div className="flex flex-col md:flex-row md:items-start justify-between">
                 <div>
-                    <h3 className="text-xl font-bold text-red-300">{lang === 'zh' ? 'AI 故障診斷' : 'AI Fault Diagnosis'}</h3>
-                    <p className="text-red-400 mt-1">{lang === 'zh' ? '實驗性 AI 分析協助故障診斷' : 'Experimental AI analysis to help diagnose the issue.'}</p>
+                    <h3 className="text-xl font-bold text-red-300">{u('AI Fault Diagnosis', 'AI 故障診斷')}</h3>
+                    <p className="text-red-400 mt-1">{u('Experimental AI analysis to help diagnose the issue.', '實驗性 AI 分析協助故障診斷')}</p>
                 </div>
                 <div className="flex space-x-2 mt-4 md:mt-0">
                     <button
@@ -376,11 +453,11 @@ const TurbineDetail: React.FC<TurbineDetailProps> = ({ turbine, onBack, onDispat
                         className="flex items-center justify-center space-x-2 bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-lg transition-all disabled:bg-gray-800 disabled:cursor-not-allowed"
                     >
                         <BrainIcon />
-                        <span>{isAnalyzing ? (lang === 'zh' ? '分析中...' : 'Analyzing...') : (lang === 'zh' ? '重新分析' : 'Re-Analyze')}</span>
+                        <span>{isAnalyzing ? u('Analyzing...', '分析中...') : u('Re-Analyze', '重新分析')}</span>
                     </button>
                     {activeWorkOrder ? (
                         <div className="text-center py-2 px-4 rounded-lg bg-yellow-500/20 text-yellow-300 border border-yellow-500/50">
-                            <p className="font-bold">{lang === 'zh' ? '工單' : 'WO'} #{activeWorkOrder.id.slice(-4)} {lang === 'zh' ? '處理中' : 'In Progress'}</p>
+                            <p className="font-bold">{u('WO', '工單')} #{activeWorkOrder.id.slice(-4)} {u('In Progress', '處理中')}</p>
                         </div>
                     ) : (
                         <button
@@ -389,12 +466,12 @@ const TurbineDetail: React.FC<TurbineDetailProps> = ({ turbine, onBack, onDispat
                             className="flex items-center justify-center space-x-2 bg-yellow-500 hover:bg-yellow-600 text-white font-bold py-2 px-4 rounded-lg transition-all disabled:bg-yellow-800 disabled:cursor-not-allowed w-full md:w-auto"
                         >
                             <WrenchScrewdriverIcon />
-                            <span>{lang === 'zh' ? '派遣技術員' : 'Dispatch Technician'}</span>
+                            <span>{u('Dispatch Technician', '派遣技術員')}</span>
                         </button>
                     )}
                 </div>
             </div>
-            {isAnalyzing && <div className="mt-4 text-center text-red-300 animate-pulse">{lang === 'zh' ? '正在聯繫維護 AI...' : 'Contacting maintenance AI...'}</div>}
+            {isAnalyzing && <div className="mt-4 text-center text-red-300 animate-pulse">{u('Contacting maintenance AI...', '正在聯繫維護 AI...')}</div>}
             {analysisError && <div className="mt-4 text-center font-bold text-red-200 bg-red-500/30 p-3 rounded">{analysisError}</div>}
             {analysisResult && (
                 <div className="mt-4 bg-gray-900/50 p-4 rounded-md text-gray-300 font-mono text-sm leading-relaxed">


### PR DESCRIPTION
## Summary
Refactored the turbine detail view to use a tabbed interface for organizing subsystem information, improving navigation and reducing cognitive load. Added a farm-wide trend chart to the farm overview showing aggregate power output and wind speed trends.

## Key Changes

### TurbineDetail Component
- **Tabbed Interface**: Introduced 7 detail tabs (Overview, Generator, Pitch/Rotor, Converter, Nacelle, Yaw, Grid/Met) with color-coded navigation buttons
- **Tab Content Rendering**: Moved all subsystem panels into a `renderTabContent()` function that displays different content based on active tab
- **Improved Organization**: Each tab now displays full-width subsystem information with dedicated trend charts, replacing the previous 3-column grid layout
- **Helper Function**: Added `u()` utility function for consistent bilingual text handling throughout the component
- **State Management**: Added `activeTab` state to track the currently selected tab

### FarmOverview Component
- **New FarmTrendChart Component**: Created a new chart component that displays:
  - Real-time farm-wide total power output (MW)
  - Average wind speed across all turbines (m/s)
  - Dual Y-axes for power and wind speed metrics
  - Time-series data with 2-second throttling and 120-point rolling window
  - Bilingual labels and tooltips
- **Layout Restructuring**: Reorganized the summary view to include the trend chart above the compact turbine grid

### Code Quality Improvements
- Extracted tab definitions into a `DETAIL_TABS` constant for maintainability
- Consistent use of bilingual helper function instead of inline ternary operators
- Better separation of concerns with tab-specific rendering logic
- Reduced spacing between header and fault alerts (mb-6 → mb-4)

## Implementation Details
- Tab styling uses color-coded backgrounds matching subsystem themes (cyan, green, purple, yellow, blue, orange)
- Active tab state persists during navigation but resets when returning to turbine detail
- Trend charts are now included in each tab rather than displayed once at the bottom
- Farm trend chart uses Recharts with responsive container and custom tooltip formatting

https://claude.ai/code/session_01DmcazBF4dujPKPjrXkNEJ4