### PR TITLE
feat: data storage architecture with sessions, downsampling, and snap…

### DIFF
--- a/server/data_broker.py
+++ b/server/data_broker.py
@@ -1,5 +1,7 @@
 import sys
 import os
+import threading
+import time as _time
 from datetime import datetime
 from typing import List, Optional, Dict
 from collections import deque
@@ -154,7 +156,23 @@ def _sim_output_to_reading(output: Dict, history_points: Optional[List[Dict]] = 
 
 
 class DataBroker:
-    """Unified data interface for simulation and real OPC data."""
+    """Unified data interface for simulation and real OPC data.
+
+    Storage strategy:
+      - Simulator runs at 1Hz, in-memory buffer keeps 1 hour
+      - SQLite writes throttled to every 10 seconds (configurable)
+      - Events trigger 1s snapshot capture (±10 min around event)
+      - Background task does downsampling and cleanup
+    """
+
+    # Default: write to SQLite every N seconds
+    WRITE_INTERVAL_S = 10
+    # Raw data retention (days)
+    RAW_RETENTION_DAYS = 3
+    # 1-min aggregate retention (days)
+    AGG_1M_RETENTION_DAYS = 90
+    # Snapshot window: seconds of 1s data to capture before/after event
+    SNAPSHOT_WINDOW_S = 600  # 10 minutes
 
     def __init__(self):
         self.mode = DataSourceMode.SIMULATION
@@ -165,6 +183,16 @@ class DataBroker:
         self._last_shutdown_cause: Dict[str, Optional[str]] = {}
         self._last_fault_trip: Dict[str, bool] = {}
         self._last_fault_alarm_keys: Dict[str, set[str]] = {}
+        # Session tracking
+        self._session_id: Optional[int] = None
+        # Write throttle state
+        self._last_write_time: float = 0
+        # Snapshot state: when an event occurs, capture 1s data for a window
+        self._snapshot_active: Dict[str, float] = {}  # turbine_id -> end_time
+        self._snapshot_event_ref: Dict[str, str] = {}
+        # Background maintenance thread
+        self._maintenance_thread: Optional[threading.Thread] = None
+        self._maintenance_running = False
 
     def start(self, config: Optional[DataSourceConfig] = None,
               sim_config: Optional[SimulationConfig] = None):
@@ -178,9 +206,16 @@ class DataBroker:
         else:
             self._start_opc(config)
 
+        # Start background maintenance (downsampling + cleanup)
+        self._start_maintenance()
+
     def _start_simulator(self):
         if self.simulator and self.simulator.is_running:
             self.simulator.stop()
+
+        # End previous session if any
+        if self._session_id is not None:
+            self.storage.end_session(self._session_id)
 
         self._last_tur_state.clear()
         self._last_shutdown_cause.clear()
@@ -192,7 +227,22 @@ class DataBroker:
             base_wind_speed=self._sim_config.baseWindSpeed,
             turbulence_intensity=self._sim_config.turbulenceIntensity,
         )
-        # Store every reading to SQLite
+
+        # Create a new session
+        self._session_id = self.storage.create_session(
+            data_source="simulation",
+            turbine_count=self._sim_config.turbineCount,
+            rated_power_kw=5000,  # default 5MW
+            model_name="Simulated 5MW",
+            config={
+                "baseWindSpeed": self._sim_config.baseWindSpeed,
+                "turbulenceIntensity": self._sim_config.turbulenceIntensity,
+                "timeStep": self._sim_config.timeStep,
+            },
+        )
+        print(f"[DataBroker] Created session #{self._session_id}")
+
+        # Register data callback (throttled writes)
         self.simulator.on_data(self._on_sim_data)
         self.simulator.start(time_step=self._sim_config.timeStep)
 
@@ -209,23 +259,103 @@ class DataBroker:
             self._start_simulator()
 
     def _on_sim_data(self, readings: List[Dict]):
-        """Callback from simulator."""
-        self.storage.store_readings(readings)
+        """Callback from simulator — called every 1s.
+
+        - Always checks for events (state changes, faults)
+        - Writes to SQLite only every WRITE_INTERVAL_S seconds
+        - If a snapshot is active for a turbine, writes 1s data to snapshots table
+        """
+        now = _time.time()
         self._detect_sim_events(readings)
 
+        # Check if any turbine has an active snapshot window
+        for reading in readings:
+            tid = reading.get('turbine_id', '')
+            snap_end = self._snapshot_active.get(tid)
+            if snap_end and now < snap_end:
+                event_ref = self._snapshot_event_ref.get(tid, '')
+                self.storage.store_snapshot(reading, event_ref, self._session_id)
+            elif snap_end and now >= snap_end:
+                del self._snapshot_active[tid]
+                del self._snapshot_event_ref[tid]
+
+        # Throttled regular writes
+        if now - self._last_write_time >= self.WRITE_INTERVAL_S:
+            self._last_write_time = now
+            self.storage.store_readings(readings, self._session_id)
+
+    def _trigger_snapshot(self, turbine_id: str, event_ref: str):
+        """Activate 1s snapshot capture for a turbine around an event.
+
+        Also retroactively saves recent in-memory history as snapshot data.
+        """
+        now = _time.time()
+        self._snapshot_active[turbine_id] = now + self.SNAPSHOT_WINDOW_S
+        self._snapshot_event_ref[turbine_id] = event_ref
+
+        # Retroactively save recent history from in-memory buffer
+        if self.simulator:
+            recent = self.simulator.get_history(turbine_id, limit=self.SNAPSHOT_WINDOW_S)
+            if recent:
+                self.storage.store_snapshots(recent, event_ref, self._session_id)
+
     def _on_opc_data(self, readings: List[Dict]):
-        """Callback from OPC adapter."""
-        self.storage.store_readings(readings)
+        """Callback from OPC adapter — uses same throttled write."""
+        now = _time.time()
+        if now - self._last_write_time >= self.WRITE_INTERVAL_S:
+            self._last_write_time = now
+            self.storage.store_readings(readings, self._session_id)
 
     def stop(self):
+        self._stop_maintenance()
         if self.simulator and self.simulator.is_running:
             self.simulator.stop()
+        if self._session_id is not None:
+            self.storage.end_session(self._session_id)
+            self._session_id = None
 
     def switch_mode(self, config: DataSourceConfig,
                     sim_config: Optional[SimulationConfig] = None):
         self.stop()
         self.mode = config.mode
         self.start(config, sim_config)
+
+    # ── Background maintenance ──
+
+    def _start_maintenance(self):
+        """Start background thread for downsampling and cleanup."""
+        if self._maintenance_running:
+            return
+        self._maintenance_running = True
+        self._maintenance_thread = threading.Thread(
+            target=self._maintenance_loop, daemon=True, name="storage-maintenance"
+        )
+        self._maintenance_thread.start()
+
+    def _stop_maintenance(self):
+        self._maintenance_running = False
+        if self._maintenance_thread:
+            self._maintenance_thread.join(timeout=5)
+            self._maintenance_thread = None
+
+    def _maintenance_loop(self):
+        """Run downsampling every 5 minutes, cleanup every hour."""
+        last_cleanup = 0
+        while self._maintenance_running:
+            _time.sleep(300)  # 5 minutes
+            if not self._maintenance_running:
+                break
+            try:
+                self.storage.run_downsampling()
+                now = _time.time()
+                if now - last_cleanup > 3600:  # hourly
+                    self.storage.run_cleanup(
+                        raw_retention_days=self.RAW_RETENTION_DAYS,
+                        agg_1m_retention_days=self.AGG_1M_RETENTION_DAYS,
+                    )
+                    last_cleanup = now
+            except Exception as e:
+                print(f"[DataBroker] Maintenance error: {e}")
 
     def get_all_turbines(self) -> List[TurbineReading]:
         if self.mode == DataSourceMode.SIMULATION and self.simulator:
@@ -325,6 +455,7 @@ class DataBroker:
             elif last_tripped != current_tripped:
                 if current_tripped:
                     tripped_faults = [f.get("scenario_id") for f in active_faults if f.get("tripped")]
+                    event_ref = f"fault_trip:{turbine_id}:{datetime.now().isoformat()}"
                     self.record_event(
                         event_type="fault",
                         source="simulator",
@@ -333,6 +464,8 @@ class DataBroker:
                         detail=f"Trip triggered by {', '.join(tripped_faults) if tripped_faults else 'active fault'}",
                         payload={"turbineId": turbine_id, "faults": tripped_faults},
                     )
+                    # Trigger high-frequency snapshot capture
+                    self._trigger_snapshot(turbine_id, event_ref)
                 else:
                     self.record_event(
                         event_type="fault",
@@ -406,6 +539,12 @@ class DataBroker:
             elif shutdown_cause in ("operator", "operator_emergency", "service"):
                 event_type = "operator"
                 title = "Operator-driven stop"
+
+            # Trigger snapshot for emergency stops and fault-caused stops
+            if current_state == 7 or (isinstance(shutdown_cause, str) and
+                                       ("fault" in shutdown_cause or "grid" in shutdown_cause or "emergency" in shutdown_cause)):
+                event_ref = f"stop:{turbine_id}:{current_state}:{datetime.now().isoformat()}"
+                self._trigger_snapshot(turbine_id, event_ref)
 
             self.record_event(
                 event_type=event_type,

--- a/server/routers/config.py
+++ b/server/routers/config.py
@@ -164,6 +164,43 @@ async def clear_grid():
 
 # ─── Turbine Specification ─────────────────────────────────────────────
 
+# ─── Storage & Session Info ───────────────────────────────────────────
+
+@router.get("/storage/stats")
+async def get_storage_stats():
+    """Get database storage statistics (row counts, size)."""
+    b = get_broker()
+    stats = b.storage.get_db_stats()
+    stats["write_interval_s"] = b.WRITE_INTERVAL_S
+    stats["raw_retention_days"] = b.RAW_RETENTION_DAYS
+    stats["agg_1m_retention_days"] = b.AGG_1M_RETENTION_DAYS
+    return stats
+
+
+@router.get("/sessions")
+async def list_sessions():
+    """List recent sessions."""
+    b = get_broker()
+    sessions = b.storage.get_sessions(limit=20)
+    active = b.storage.get_active_session()
+    return {"active_session_id": active["id"] if active else None, "sessions": sessions}
+
+
+@router.post("/storage/maintenance")
+async def run_maintenance():
+    """Manually trigger downsampling and cleanup."""
+    b = get_broker()
+    b.storage.run_downsampling()
+    cleanup = b.storage.run_cleanup(
+        raw_retention_days=b.RAW_RETENTION_DAYS,
+        agg_1m_retention_days=b.AGG_1M_RETENTION_DAYS,
+    )
+    stats = b.storage.get_db_stats()
+    return {"cleanup": cleanup, "stats": stats}
+
+
+# ─── Turbine Specification ─────────────────────────────────────────────
+
 @router.get("/turbine-spec")
 async def get_turbine_spec():
     """Get current turbine specification."""
@@ -209,7 +246,19 @@ async def set_turbine_spec(spec_dict: dict):
     for model in b.simulator.turbines.values():
         model.update_spec(new_spec)
 
-    return {"status": "ok", "spec": new_spec.to_dict()}
+    # Create a new session to separate data from different turbine models
+    if b._session_id is not None:
+        b.storage.end_session(b._session_id)
+    b._session_id = b.storage.create_session(
+        data_source="simulation",
+        turbine_count=len(b.turbine_ids),
+        rated_power_kw=new_spec.rated_power_kw,
+        rotor_diameter_m=new_spec.rotor_diameter_m,
+        model_name=preset_name or "Custom",
+        config=new_spec.to_dict(),
+    )
+
+    return {"status": "ok", "spec": new_spec.to_dict(), "session_id": b._session_id}
 
 
 @router.get("/turbine-spec/presets")

--- a/server/storage.py
+++ b/server/storage.py
@@ -1,8 +1,9 @@
 import sqlite3
 import json
 import threading
-from datetime import datetime
-from typing import List, Optional
+import time as _time
+from datetime import datetime, timedelta
+from typing import List, Optional, Dict
 from pathlib import Path
 
 
@@ -10,7 +11,15 @@ DB_PATH = Path(__file__).parent.parent / "wind_farm_data.db"
 
 
 class Storage:
-    """SQLite-based time-series storage for turbine readings and history events."""
+    """SQLite-based time-series storage for turbine readings and history events.
+
+    Data tiers:
+      - turbine_data:        10s writes (configurable), 3-day retention for raw
+      - turbine_data_1m:     1-min aggregates, 90-day retention
+      - turbine_data_10m:    10-min aggregates, permanent
+      - turbine_snapshots:   1s high-freq capture around events, permanent
+      - sessions:            tracks simulation/data source configs
+    """
 
     def __init__(self, db_path: str = str(DB_PATH)):
         self._db_path = db_path
@@ -25,11 +34,14 @@ class Storage:
 
     def _init_db(self):
         conn = sqlite3.connect(self._db_path)
+
+        # ── Main raw data table (10s interval writes) ──
         conn.execute("""
             CREATE TABLE IF NOT EXISTS turbine_data (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 timestamp TEXT NOT NULL,
                 turbine_id TEXT NOT NULL,
+                session_id INTEGER,
                 status TEXT,
                 tur_state INTEGER,
                 wind_speed REAL,
@@ -44,7 +56,6 @@ class Storage:
                 gearbox_temp REAL,
                 frequency REAL,
                 hydraulic_pressure REAL,
-                -- Extended SCADA fields (v2)
                 scada_json TEXT
             )
         """)
@@ -52,6 +63,90 @@ class Storage:
             CREATE INDEX IF NOT EXISTS idx_turbine_time
             ON turbine_data (turbine_id, timestamp)
         """)
+
+        # ── 1-minute aggregate table ──
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS turbine_data_1m (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL,
+                turbine_id TEXT NOT NULL,
+                session_id INTEGER,
+                power_output_avg REAL,
+                power_output_max REAL,
+                power_output_min REAL,
+                wind_speed_avg REAL,
+                wind_speed_max REAL,
+                rotor_speed_avg REAL,
+                temperature_avg REAL,
+                vibration_avg REAL,
+                vibration_max REAL,
+                sample_count INTEGER
+            )
+        """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_1m_turbine_time
+            ON turbine_data_1m (turbine_id, timestamp)
+        """)
+
+        # ── 10-minute aggregate table ──
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS turbine_data_10m (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL,
+                turbine_id TEXT NOT NULL,
+                session_id INTEGER,
+                power_output_avg REAL,
+                power_output_max REAL,
+                power_output_min REAL,
+                wind_speed_avg REAL,
+                wind_speed_max REAL,
+                rotor_speed_avg REAL,
+                temperature_avg REAL,
+                vibration_avg REAL,
+                vibration_max REAL,
+                sample_count INTEGER
+            )
+        """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_10m_turbine_time
+            ON turbine_data_10m (turbine_id, timestamp)
+        """)
+
+        # ── Event snapshots (1s high-freq around events) ──
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS turbine_snapshots (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL,
+                turbine_id TEXT NOT NULL,
+                session_id INTEGER,
+                event_ref TEXT,
+                wind_speed REAL,
+                power_output REAL,
+                rotor_speed REAL,
+                scada_json TEXT
+            )
+        """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_snapshots_turbine_time
+            ON turbine_snapshots (turbine_id, timestamp)
+        """)
+
+        # ── Sessions table ──
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS sessions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                started_at TEXT NOT NULL,
+                ended_at TEXT,
+                data_source TEXT NOT NULL,
+                turbine_count INTEGER,
+                rated_power_kw REAL,
+                rotor_diameter_m REAL,
+                model_name TEXT,
+                config_json TEXT
+            )
+        """)
+
+        # ── History events (existing) ──
         conn.execute("""
             CREATE TABLE IF NOT EXISTS history_events (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -69,21 +164,94 @@ class Storage:
             CREATE INDEX IF NOT EXISTS idx_history_events_turbine_time
             ON history_events (turbine_id, timestamp)
         """)
-        # Add scada_json column if upgrading from v1 schema
-        try:
-            conn.execute("SELECT scada_json FROM turbine_data LIMIT 1")
-        except sqlite3.OperationalError:
-            conn.execute("ALTER TABLE turbine_data ADD COLUMN scada_json TEXT")
-        try:
-            conn.execute("SELECT tur_state FROM turbine_data LIMIT 1")
-        except sqlite3.OperationalError:
-            conn.execute("ALTER TABLE turbine_data ADD COLUMN tur_state INTEGER")
-        try:
-            conn.execute("SELECT end_timestamp FROM history_events LIMIT 1")
-        except sqlite3.OperationalError:
-            conn.execute("ALTER TABLE history_events ADD COLUMN end_timestamp TEXT")
+
+        # ── Migrations for existing DBs ──
+        self._migrate_columns(conn, "turbine_data", [
+            ("scada_json", "TEXT"),
+            ("tur_state", "INTEGER"),
+            ("session_id", "INTEGER"),
+        ])
+        self._migrate_columns(conn, "history_events", [
+            ("end_timestamp", "TEXT"),
+        ])
+
         conn.commit()
         conn.close()
+
+    def _migrate_columns(self, conn, table: str, columns: list):
+        """Add missing columns to existing tables."""
+        for col_name, col_type in columns:
+            try:
+                conn.execute(f"SELECT {col_name} FROM {table} LIMIT 1")
+            except sqlite3.OperationalError:
+                conn.execute(f"ALTER TABLE {table} ADD COLUMN {col_name} {col_type}")
+
+    # ══════════════════════════════════════════════════════════════════
+    #  Session Management
+    # ══════════════════════════════════════════════════════════════════
+
+    def create_session(self, data_source: str, turbine_count: int,
+                       rated_power_kw: float = None, rotor_diameter_m: float = None,
+                       model_name: str = None, config: dict = None) -> int:
+        """Create a new session and return its ID."""
+        conn = self._get_conn()
+        cursor = conn.execute("""
+            INSERT INTO sessions (started_at, data_source, turbine_count,
+                                  rated_power_kw, rotor_diameter_m, model_name, config_json)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        """, (
+            datetime.now().isoformat(),
+            data_source,
+            turbine_count,
+            rated_power_kw,
+            rotor_diameter_m,
+            model_name,
+            json.dumps(config) if config else None,
+        ))
+        conn.commit()
+        return cursor.lastrowid
+
+    def end_session(self, session_id: int):
+        """Mark a session as ended."""
+        conn = self._get_conn()
+        conn.execute("UPDATE sessions SET ended_at = ? WHERE id = ?",
+                     (datetime.now().isoformat(), session_id))
+        conn.commit()
+
+    def get_sessions(self, limit: int = 20) -> List[dict]:
+        conn = self._get_conn()
+        rows = conn.execute(
+            "SELECT * FROM sessions ORDER BY id DESC LIMIT ?", (limit,)
+        ).fetchall()
+        result = []
+        for row in rows:
+            d = dict(row)
+            if d.get("config_json"):
+                try:
+                    d["config"] = json.loads(d["config_json"])
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            result.append(d)
+        return result
+
+    def get_active_session(self) -> Optional[dict]:
+        conn = self._get_conn()
+        row = conn.execute(
+            "SELECT * FROM sessions WHERE ended_at IS NULL ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        if row:
+            d = dict(row)
+            if d.get("config_json"):
+                try:
+                    d["config"] = json.loads(d["config_json"])
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            return d
+        return None
+
+    # ══════════════════════════════════════════════════════════════════
+    #  Data Writing
+    # ══════════════════════════════════════════════════════════════════
 
     def record_event(
         self,
@@ -140,7 +308,7 @@ class Storage:
         conn.execute(query, params)
         conn.commit()
 
-    def store_reading(self, reading: dict):
+    def store_reading(self, reading: dict, session_id: int = None):
         """Store a single turbine reading (from simulator output dict)."""
         conn = self._get_conn()
 
@@ -150,22 +318,21 @@ class Storage:
             except (TypeError, ValueError):
                 return default
 
-        # Serialize full SCADA dict if available
         scada = reading.get('scada', {})
         scada_json = json.dumps(scada) if scada else None
-
         tur_state = int(scada.get("WTUR_TurSt", 0)) if scada else None
 
         conn.execute("""
             INSERT INTO turbine_data
-            (timestamp, turbine_id, status, tur_state, wind_speed, power_output,
+            (timestamp, turbine_id, session_id, status, tur_state, wind_speed, power_output,
              rotor_speed, blade_angle, temperature, vibration, voltage,
              current_amp, yaw_angle, gearbox_temp, frequency, hydraulic_pressure,
              scada_json)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (
             str(reading.get('timestamp', datetime.now().isoformat())),
             str(reading.get('turbine_id', '')),
+            session_id,
             str(reading.get('operational_state', 'IDLE')),
             tur_state,
             to_float(reading.get('wind_speed', 0)),
@@ -184,9 +351,163 @@ class Storage:
         ))
         conn.commit()
 
-    def store_readings(self, readings: List[dict]):
+    def store_readings(self, readings: List[dict], session_id: int = None):
         for r in readings:
-            self.store_reading(r)
+            self.store_reading(r, session_id)
+
+    def store_snapshot(self, reading: dict, event_ref: str, session_id: int = None):
+        """Store a 1s snapshot reading linked to an event."""
+        conn = self._get_conn()
+        scada = reading.get('scada', {})
+        scada_json = json.dumps(scada) if scada else None
+
+        def to_float(v, default=0.0):
+            try:
+                return float(v) if v is not None else default
+            except (TypeError, ValueError):
+                return default
+
+        conn.execute("""
+            INSERT INTO turbine_snapshots
+            (timestamp, turbine_id, session_id, event_ref, wind_speed, power_output,
+             rotor_speed, scada_json)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """, (
+            str(reading.get('timestamp', datetime.now().isoformat())),
+            str(reading.get('turbine_id', '')),
+            session_id,
+            event_ref,
+            to_float(reading.get('wind_speed', 0)),
+            to_float(reading.get('total_power', 0)) / 1_000_000,
+            to_float(scada.get('WROT_RotSpd', reading.get('rotor', {}).get('rotor_speed', 0))),
+            scada_json,
+        ))
+        conn.commit()
+
+    def store_snapshots(self, readings: List[dict], event_ref: str, session_id: int = None):
+        for r in readings:
+            self.store_snapshot(r, event_ref, session_id)
+
+    # ══════════════════════════════════════════════════════════════════
+    #  Data Retention & Downsampling
+    # ══════════════════════════════════════════════════════════════════
+
+    def run_downsampling(self):
+        """Create 1-minute and 10-minute aggregates from raw data.
+
+        Called periodically by the background maintenance task.
+        """
+        conn = self._get_conn()
+        now = datetime.now()
+
+        # ── Build 1-minute aggregates from raw data older than 5 minutes ──
+        cutoff_1m = (now - timedelta(minutes=5)).isoformat()
+        # Find the latest 1m aggregate timestamp to avoid re-processing
+        latest_1m = conn.execute(
+            "SELECT MAX(timestamp) FROM turbine_data_1m"
+        ).fetchone()[0]
+        from_ts = latest_1m or "2000-01-01T00:00:00"
+
+        rows = conn.execute("""
+            INSERT INTO turbine_data_1m
+                (timestamp, turbine_id, session_id,
+                 power_output_avg, power_output_max, power_output_min,
+                 wind_speed_avg, wind_speed_max, rotor_speed_avg,
+                 temperature_avg, vibration_avg, vibration_max, sample_count)
+            SELECT
+                MIN(timestamp),
+                turbine_id,
+                session_id,
+                AVG(power_output), MAX(power_output), MIN(power_output),
+                AVG(wind_speed), MAX(wind_speed), AVG(rotor_speed),
+                AVG(temperature), AVG(vibration), MAX(vibration),
+                COUNT(*)
+            FROM turbine_data
+            WHERE timestamp > ? AND timestamp <= ?
+            GROUP BY turbine_id,
+                     CAST(strftime('%s', timestamp) AS INTEGER) / 60
+            HAVING COUNT(*) > 0
+        """, (from_ts, cutoff_1m))
+        conn.commit()
+
+        # ── Build 10-minute aggregates from 1-min data older than 15 minutes ──
+        cutoff_10m = (now - timedelta(minutes=15)).isoformat()
+        latest_10m = conn.execute(
+            "SELECT MAX(timestamp) FROM turbine_data_10m"
+        ).fetchone()[0]
+        from_ts_10m = latest_10m or "2000-01-01T00:00:00"
+
+        conn.execute("""
+            INSERT INTO turbine_data_10m
+                (timestamp, turbine_id, session_id,
+                 power_output_avg, power_output_max, power_output_min,
+                 wind_speed_avg, wind_speed_max, rotor_speed_avg,
+                 temperature_avg, vibration_avg, vibration_max, sample_count)
+            SELECT
+                MIN(timestamp),
+                turbine_id,
+                session_id,
+                AVG(power_output_avg), MAX(power_output_max), MIN(power_output_min),
+                AVG(wind_speed_avg), MAX(wind_speed_max), AVG(rotor_speed_avg),
+                AVG(temperature_avg), AVG(vibration_avg), MAX(vibration_max),
+                SUM(sample_count)
+            FROM turbine_data_1m
+            WHERE timestamp > ? AND timestamp <= ?
+            GROUP BY turbine_id,
+                     CAST(strftime('%s', timestamp) AS INTEGER) / 600
+            HAVING COUNT(*) > 0
+        """, (from_ts_10m, cutoff_10m))
+        conn.commit()
+
+    def run_cleanup(self, raw_retention_days: int = 3, agg_1m_retention_days: int = 90):
+        """Delete old raw data and old 1-minute aggregates.
+
+        - Raw (turbine_data): keep last `raw_retention_days` days (default 3)
+        - 1-minute aggregates: keep last `agg_1m_retention_days` days (default 90)
+        - 10-minute aggregates: keep forever
+        - Snapshots: keep forever
+        """
+        conn = self._get_conn()
+        now = datetime.now()
+
+        raw_cutoff = (now - timedelta(days=raw_retention_days)).isoformat()
+        deleted_raw = conn.execute(
+            "DELETE FROM turbine_data WHERE timestamp < ?", (raw_cutoff,)
+        ).rowcount
+
+        agg_cutoff = (now - timedelta(days=agg_1m_retention_days)).isoformat()
+        deleted_1m = conn.execute(
+            "DELETE FROM turbine_data_1m WHERE timestamp < ?", (agg_cutoff,)
+        ).rowcount
+
+        conn.commit()
+
+        if deleted_raw > 0 or deleted_1m > 0:
+            print(f"[Storage] Cleanup: removed {deleted_raw} raw rows, {deleted_1m} 1m-agg rows")
+
+        return {"deleted_raw": deleted_raw, "deleted_1m": deleted_1m}
+
+    def get_db_stats(self) -> dict:
+        """Return row counts and estimated sizes for each table."""
+        conn = self._get_conn()
+        tables = ["turbine_data", "turbine_data_1m", "turbine_data_10m",
+                   "turbine_snapshots", "history_events", "sessions"]
+        stats = {}
+        for table in tables:
+            try:
+                count = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+                stats[table] = count
+            except sqlite3.OperationalError:
+                stats[table] = 0
+
+        # DB file size
+        db_path = Path(self._db_path)
+        stats["db_size_mb"] = round(db_path.stat().st_size / (1024 * 1024), 1) if db_path.exists() else 0
+        return stats
+
+    # ══════════════════════════════════════════════════════════════════
+    #  Data Queries
+    # ══════════════════════════════════════════════════════════════════
 
     def query_history(self, turbine_id: str, start: Optional[str] = None,
                       end: Optional[str] = None, limit: int = 1000) -> List[dict]:
@@ -208,7 +529,6 @@ class Storage:
         result = []
         for row in rows:
             d = dict(row)
-            # Expand scada_json back to dict if available
             if d.get('scada_json'):
                 try:
                     d['scada'] = json.loads(d['scada_json'])
@@ -272,3 +592,32 @@ class Storage:
             ORDER BY t1.turbine_id
         """).fetchall()
         return [dict(row) for row in rows]
+
+    def query_snapshots(self, turbine_id: str, event_ref: Optional[str] = None,
+                        start: Optional[str] = None, end: Optional[str] = None,
+                        limit: int = 1000) -> List[dict]:
+        conn = self._get_conn()
+        query = "SELECT * FROM turbine_snapshots WHERE turbine_id = ?"
+        params: list = [turbine_id]
+        if event_ref:
+            query += " AND event_ref = ?"
+            params.append(event_ref)
+        if start:
+            query += " AND timestamp >= ?"
+            params.append(start)
+        if end:
+            query += " AND timestamp <= ?"
+            params.append(end)
+        query += " ORDER BY timestamp ASC LIMIT ?"
+        params.append(limit)
+        rows = conn.execute(query, params).fetchall()
+        result = []
+        for row in rows:
+            d = dict(row)
+            if d.get('scada_json'):
+                try:
+                    d['scada'] = json.loads(d['scada_json'])
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            result.append(d)
+        return result


### PR DESCRIPTION
…shots

Storage strategy to control disk usage:
- Write throttle: SQLite writes every 10s instead of 1s (~10x reduction)
- Data tiering: raw (3-day retention) → 1-min aggregates (90 days) → 10-min aggregates (permanent)
- Event snapshots: 1s high-frequency capture around faults and emergency stops, stored permanently for forensic analysis
- Background maintenance: auto downsampling every 5 min, cleanup hourly

Session management:
- Each simulator start or turbine spec change creates a new session
- Sessions track data source, turbine count, rated power, model name
- All stored data linked to session_id for filtering by turbine model
- Prevents data confusion when switching between 3MW/5MW/8MW models

New API endpoints:
- GET /api/config/storage/stats - DB row counts, file size, settings
- GET /api/config/sessions - list sessions with active session
- POST /api/config/storage/maintenance - manual trigger for cleanup

https://claude.ai/code/session_01DmcazBF4dujPKPjrXkNEJ4