### PR TITLE
feat: calibrate simulator to Z72-2000-MV OEM specifications

### DIFF
--- a/server/data_broker.py
+++ b/server/data_broker.py
@@ -232,8 +232,8 @@ class DataBroker:
         self._session_id = self.storage.create_session(
             data_source="simulation",
             turbine_count=self._sim_config.turbineCount,
-            rated_power_kw=5000,  # default 5MW
-            model_name="Simulated 5MW",
+            rated_power_kw=2000,  # Z72-2000-MV default
+            model_name="Z72-2000-MV",
             config={
                 "baseWindSpeed": self._sim_config.baseWindSpeed,
                 "turbulenceIntensity": self._sim_config.turbulenceIntensity,

--- a/simulator/physics/power_curve.py
+++ b/simulator/physics/power_curve.py
@@ -12,24 +12,23 @@ import numpy as np
 from typing import List, Tuple, Optional
 
 
-# ─── Default Z72 5MW power curve (from typical 5MW offshore data) ────────
+# ─── Default Z72-2000-MV power curve (Harakosan 2MW direct-drive) ────────
 # (wind_speed_m_s, power_kw)
-# Region 1: 0 → cut-in (0 kW)
-# Region 2: cut-in → rated (cubic growth)
-# Region 3: rated → cut-out (constant at rated)
-DEFAULT_5MW_POWER_CURVE: List[Tuple[float, float]] = [
+# Based on Z72 OEM data: rated 2000kW, cut-in 3m/s, rated 13m/s, cut-out 25m/s
+# Rotor diameter 70.65m, direct-drive PMSG
+DEFAULT_Z72_POWER_CURVE: List[Tuple[float, float]] = [
     (0.0, 0), (2.0, 0), (3.0, 0),          # Below cut-in
-    (3.5, 40), (4.0, 100), (4.5, 180),      # Region 2 start
-    (5.0, 290), (5.5, 430), (6.0, 610),
-    (6.5, 830), (7.0, 1090), (7.5, 1400),
-    (8.0, 1750), (8.5, 2150), (9.0, 2600),
-    (9.5, 3050), (10.0, 3500), (10.5, 3950),
-    (11.0, 4350), (11.5, 4700), (12.0, 4950),  # Approaching rated
-    (12.5, 5000), (13.0, 5000), (14.0, 5000),  # Region 3 (constant)
-    (15.0, 5000), (16.0, 5000), (17.0, 5000),
-    (18.0, 5000), (19.0, 5000), (20.0, 5000),
-    (21.0, 5000), (22.0, 5000), (23.0, 5000),
-    (24.0, 5000), (25.0, 5000),                # Cut-out
+    (3.5, 15), (4.0, 40), (4.5, 75),       # Region 2 start
+    (5.0, 120), (5.5, 175), (6.0, 245),
+    (6.5, 330), (7.0, 435), (7.5, 555),
+    (8.0, 690), (8.5, 845), (9.0, 1010),
+    (9.5, 1185), (10.0, 1365), (10.5, 1540),
+    (11.0, 1700), (11.5, 1830), (12.0, 1930),  # Approaching rated
+    (12.5, 1980), (13.0, 2000), (14.0, 2000),  # Region 3 (constant)
+    (15.0, 2000), (16.0, 2000), (17.0, 2000),
+    (18.0, 2000), (19.0, 2000), (20.0, 2000),
+    (21.0, 2000), (22.0, 2000), (23.0, 2000),
+    (24.0, 2000), (25.0, 2000),                # Cut-out
     (25.5, 0), (26.0, 0),                       # Storm shutdown
 ]
 
@@ -55,10 +54,10 @@ class PowerCurveModel:
             self._ws = np.array([p[0] for p in power_curve])
             self._pw = np.array([p[1] for p in power_curve])
         else:
-            self._ws = np.array([p[0] for p in DEFAULT_5MW_POWER_CURVE])
-            self._pw = np.array([p[1] for p in DEFAULT_5MW_POWER_CURVE])
-            # Scale to rated power
-            scale = rated_power_kw / 5000.0
+            self._ws = np.array([p[0] for p in DEFAULT_Z72_POWER_CURVE])
+            self._pw = np.array([p[1] for p in DEFAULT_Z72_POWER_CURVE])
+            # Scale to rated power (base curve is 2000kW Z72)
+            scale = rated_power_kw / 2000.0
             self._pw = self._pw * scale
 
     def get_power(self, wind_speed: float) -> float:

--- a/simulator/physics/thermal_model.py
+++ b/simulator/physics/thermal_model.py
@@ -38,11 +38,21 @@ class ThermalElement:
 
 @dataclass
 class ThermalSystemConfig:
-    """Calibrated thermal parameters for a 5MW turbine."""
+    """Calibrated thermal parameters for Z72-2000-MV turbine.
 
-    gen_stator: tuple = (0.24, 600, 35.0)
-    gen_air: tuple = (0.32, 450, 30.0)
-    gen_bearing: tuple = (0.70, 900, 30.0)
+    Z72 OEM thresholds:
+      Gen stator: alarm 140°C, trip 150°C
+      Gen bearing: alarm 85°C, trip 95°C
+      Rotor cabinet: alarm 45°C, trip 50°C
+      Nacelle cabinet: alarm 45°C, trip 50°C
+    Tuned so normal operation reaches ~60-80% of alarm thresholds.
+    """
+
+    # (thermal_resistance, time_constant_s, initial_temp)
+    # Z72: direct-drive PMSG → stator thermal R lower (better cooling)
+    gen_stator: tuple = (0.035, 600, 35.0)   # Stator: alarm@140, trip@150
+    gen_air: tuple = (0.045, 450, 30.0)      # Air gap
+    gen_bearing: tuple = (0.025, 900, 30.0)  # Main bearing: alarm@85, trip@95
 
     cnv_cabinet: tuple = (0.20, 500, 28.0)
     cnv_water: tuple = (0.17, 300, 25.0)
@@ -50,10 +60,10 @@ class ThermalSystemConfig:
     transformer: tuple = (0.70, 1200, 30.0)
 
     nacelle: tuple = (0.08, 1800, 25.0)
-    nac_cabinet: tuple = (0.75, 300, 28.0)
+    nac_cabinet: tuple = (0.75, 300, 28.0)   # alarm@45, trip@50
 
     rotor: tuple = (0.10, 600, 25.0)
-    hub_cabinet: tuple = (0.30, 300, 28.0)
+    hub_cabinet: tuple = (0.30, 300, 28.0)   # alarm@45, trip@50
 
 
 class ThermalSystem:

--- a/simulator/physics/turbine_physics.py
+++ b/simulator/physics/turbine_physics.py
@@ -26,28 +26,67 @@ from simulator.physics.yaw_model import YawModel
 class TurbineSpec:
     """Configurable wind turbine specifications."""
 
-    rated_power_kw: float = 5000.0
-    rotor_diameter: float = 126.0
-    hub_height: float = 90.0
+    rated_power_kw: float = 2000.0
+    rotor_diameter: float = 70.65
+    hub_height: float = 64.0
     cut_in_speed: float = 3.0
-    rated_speed: float = 12.0
+    rated_speed: float = 13.0
     cut_out_speed: float = 25.0
 
-    gear_ratio: float = 100.0
+    # Z72: direct-drive PMSG, no gearbox (gear_ratio=1)
+    gear_ratio: float = 1.0
     generator_efficiency: float = 0.95
-    generator_poles: int = 4
-    nominal_voltage: float = 690.0
+    generator_poles: int = 60
+    nominal_voltage: float = 3500.0  # Z72 MV generator: 3.5kV
     air_density: float = 1.225
 
-    max_rotor_rpm: float = 15.0
-    optimal_tsr: float = 7.5
-    cp_max: float = 0.48
+    max_rotor_rpm: float = 22.5
+    optimal_tsr: float = 7.0
+    cp_max: float = 0.45
+
+    # Z72 protection setpoints
+    overspeed_software_rpm: float = 26.5
+    overspeed_hardware_rpm: float = 28.5
+    power_limit_5s_pct: float = 1.10   # 110% of rated
+    power_limit_10m_pct: float = 1.05  # 105% of rated
+    max_restarts_per_hour: int = 3
+
+    # Z72 pitch angles (degrees)
+    pitch_vane: float = 86.0      # feathered / emergency
+    pitch_startup: float = 30.0   # startup position
+    pitch_work: float = -1.0      # optimal production
+    pitch_emergency_rate: float = 5.0  # min deg/s for emergency pitch
+
+    # Z72 temperature thresholds (°C)
+    gen_stator_alarm: float = 140.0
+    gen_stator_trip: float = 150.0
+    gen_bearing_alarm: float = 85.0
+    gen_bearing_trip: float = 95.0
+    nacelle_cab_alarm: float = 45.0
+    nacelle_cab_trip: float = 50.0
+    rotor_cab_alarm: float = 45.0
+    rotor_cab_trip: float = 50.0
+    outside_temp_low: float = -25.0
+    outside_temp_high: float = 45.0
+
+    # Z72 yaw thresholds
+    yaw_pressure_trip: float = 150.0     # bar, very low
+    yaw_pressure_alarm: float = 170.0    # bar, low
+    yaw_pressure_normal: float = 210.0   # bar, high friction
+    cable_twist_limit: float = 2.5       # turns
+
+    # Z72 grid (60Hz system)
+    grid_frequency_nominal: float = 60.0
 
     curtailment_kw: Optional[float] = None
     power_curve: Optional[List[Tuple[float, float]]] = None
 
+    rotor_diameter_m: Optional[float] = None  # alias for session tracking
+
     def to_dict(self) -> dict:
-        return {k: getattr(self, k) for k in self.__dataclass_fields__}
+        d = {k: getattr(self, k) for k in self.__dataclass_fields__}
+        d['rotor_diameter_m'] = self.rotor_diameter
+        return d
 
     @classmethod
     def from_dict(cls, d: dict) -> "TurbineSpec":
@@ -55,23 +94,28 @@ class TurbineSpec:
 
 
 TURBINE_PRESETS: Dict[str, TurbineSpec] = {
-    "z72_5mw": TurbineSpec(),
+    # Default: Z72-2000-MV (Harakosan, direct-drive PMSG, 60Hz)
+    "z72_2mw": TurbineSpec(),
     "vestas_v90_3mw": TurbineSpec(
         rated_power_kw=3000, rotor_diameter=90, hub_height=80,
         cut_in_speed=4.0, rated_speed=13.0, cut_out_speed=25.0,
-        gear_ratio=104.5, max_rotor_rpm=16.7, optimal_tsr=8.0,
+        gear_ratio=104.5, generator_poles=4, nominal_voltage=690.0,
+        max_rotor_rpm=16.7, optimal_tsr=8.0,
+        grid_frequency_nominal=60.0,
     ),
     "sg_8mw": TurbineSpec(
         rated_power_kw=8000, rotor_diameter=167, hub_height=92,
         cut_in_speed=3.0, rated_speed=12.0, cut_out_speed=25.0,
-        gear_ratio=1.0, generator_poles=300, max_rotor_rpm=10.6,
-        optimal_tsr=9.0, cp_max=0.49,
+        gear_ratio=1.0, generator_poles=300, nominal_voltage=690.0,
+        max_rotor_rpm=10.6, optimal_tsr=9.0, cp_max=0.49,
+        grid_frequency_nominal=50.0,
     ),
     "goldwind_2.5mw": TurbineSpec(
         rated_power_kw=2500, rotor_diameter=121, hub_height=90,
         cut_in_speed=3.0, rated_speed=10.3, cut_out_speed=22.0,
-        gear_ratio=1.0, generator_poles=96, max_rotor_rpm=11.5,
-        optimal_tsr=8.5, cp_max=0.47,
+        gear_ratio=1.0, generator_poles=96, nominal_voltage=690.0,
+        max_rotor_rpm=11.5, optimal_tsr=8.5, cp_max=0.47,
+        grid_frequency_nominal=50.0,
     ),
 }
 
@@ -145,8 +189,8 @@ class TurbinePhysicsModel:
 
         self.tur_state = 1
         self.rotor_speed = 0.0
-        self.pitch_angle = 90.0
-        self._pitch_bl = [90.0, 90.0, 90.0]
+        self.pitch_angle = self.spec.pitch_vane  # Z72: vane position (86°)
+        self._pitch_bl = [self.spec.pitch_vane] * 3
         self._sim_time = 0.0
         self._generated_power_kw = 0.0
         self._generator_speed = 0.0
@@ -164,9 +208,11 @@ class TurbinePhysicsModel:
         self._grid_phase = self._rng.uniform(0.0, math.tau)
         self._grid_local_phase = self._rng.uniform(0.0, math.tau)
         self._grid_voltage_ref = self.spec.nominal_voltage + self._individuality["grid_voltage_bias"]
-        self._grid_frequency_ref = 50.0
+        self._grid_frequency_ref = self.spec.grid_frequency_nominal
         self._grid_normal_trip_accum = 0.0
         self._grid_emergency_trip_accum = 0.0
+        # Z72: restart tracking (max restarts per hour)
+        self._restart_timestamps: List[float] = []
         self._pitch_offset_bl = [self._rng.normal(0, 0.12) for _ in range(3)]
         self._pitch_stiction = [0.0, 0.0, 0.0]
         self._sensor_bias: Dict[str, float] = {}
@@ -284,8 +330,13 @@ class TurbinePhysicsModel:
         self._calc_pitch(effective_wind_speed, is_producing, dt)
         self._pitch_bl[0] += fault_physics["blade1_pitch_bias"]
 
+        # For direct-drive PMSG, the converter outputs grid frequency regardless of rotor speed
         mechanical_freq = (gen_speed * s.generator_poles / 2) / 60.0 if (is_producing or is_starting) else 0.0
-        target_freq = self._grid_frequency_ref if is_producing else mechanical_freq if is_starting else 0.0
+        if s.gear_ratio <= 1.0:
+            # Direct-drive: converter always outputs grid frequency when producing
+            target_freq = self._grid_frequency_ref if (is_producing or is_starting) else 0.0
+        else:
+            target_freq = self._grid_frequency_ref if is_producing else mechanical_freq if is_starting else 0.0
         target_voltage = self._grid_voltage_ref if (is_producing or is_starting) else 0.0
         elec_alpha = 1.0 - math.exp(-dt / (1.0 if is_producing else 0.75))
         self._grid_frequency += (target_freq - self._grid_frequency) * elec_alpha
@@ -422,15 +473,29 @@ class TurbinePhysicsModel:
 
         return self._apply_sensor_model(output)
 
+    def _max_restarts_exceeded(self) -> bool:
+        """Z72: Check if max restarts per hour has been exceeded."""
+        cutoff = self._sim_time - 3600.0
+        self._restart_timestamps = [t for t in self._restart_timestamps if t > cutoff]
+        return len(self._restart_timestamps) >= self.spec.max_restarts_per_hour
+
     def _update_state(self, wind_speed: float, dt: float):
         s = self.spec
         st = self.tur_state
         wind_ok = s.cut_in_speed <= wind_speed <= s.cut_out_speed
         strong_wind = wind_speed >= s.cut_in_speed + 0.6
-        sync_ok = (
-            abs(self._grid_frequency_ref - ((self.rotor_speed * s.gear_ratio * s.generator_poles / 2) / 60.0 if self.rotor_speed > 0 else 0.0)) < 0.25
-            and abs(self._grid_voltage_ref - self._grid_voltage) < 25.0
-        )
+        # Z72 direct-drive: converter decouples gen freq from grid freq.
+        # For direct-drive (gear_ratio <= 1), sync is based on rotor speed threshold.
+        # For geared turbines, sync requires frequency/voltage matching.
+        if s.gear_ratio <= 1.0:
+            # Direct-drive: converter ready when rotor reaches ~6 RPM (Z72 OEM spec)
+            sync_ok = self.rotor_speed >= 6.0
+        else:
+            gen_mech_freq = (self.rotor_speed * s.gear_ratio * s.generator_poles / 2) / 60.0 if self.rotor_speed > 0 else 0.0
+            sync_ok = (
+                abs(self._grid_frequency_ref - gen_mech_freq) < 0.25
+                and abs(self._grid_voltage_ref - self._grid_voltage) < 25.0
+            )
 
         self._state_timer += dt
         self._restart_block_timer = max(0.0, self._restart_block_timer - dt)
@@ -438,6 +503,12 @@ class TurbinePhysicsModel:
             self._wind_ready_timer += dt
         else:
             self._wind_ready_timer = 0.0
+
+        # Z72: Software overspeed protection (Event 041 / 027)
+        if self.rotor_speed > s.overspeed_software_rpm and st not in (7,):
+            self._request_stop("emergency", "overspeed_software")
+        if self.rotor_speed > s.overspeed_hardware_rpm and st not in (7,):
+            self._request_stop("emergency", "overspeed_hardware")
 
         if self.operator_stop or self.service_mode:
             self._request_stop("normal", "operator")
@@ -449,18 +520,23 @@ class TurbinePhysicsModel:
             st = self.tur_state
 
         if self.operator_start_pending and st in (1, 2, 3) and wind_ok and self._restart_block_timer <= 0.0:
-            self.operator_start_pending = False
-            self._enter_state(8 if st == 3 else 4)
-            st = self.tur_state
+            if not self._max_restarts_exceeded():
+                self.operator_start_pending = False
+                self._restart_timestamps.append(self._sim_time)
+                self._enter_state(8 if st == 3 else 4)
+                st = self.tur_state
 
         if st == 1:
             self._sync_progress = 0.0
-            if wind_ok:
+            if wind_ok and not self._max_restarts_exceeded():
                 self._enter_state(2)
         elif st == 2:
             if not wind_ok:
                 self._enter_state(1)
+            elif self._max_restarts_exceeded():
+                pass  # Z72: stay in standby if max restarts exceeded
             elif not self.operator_stop and self._wind_ready_timer >= 10.0 + self._individuality["start_delay_offset"] and self._restart_block_timer <= 0.0:
+                self._restart_timestamps.append(self._sim_time)
                 self._enter_state(4)
         elif st == 3:
             self._restart_wait_timer += dt
@@ -469,18 +545,24 @@ class TurbinePhysicsModel:
                 + self._individuality["restart_delay_offset"]
                 + max(0.0, self._individuality["grid_reconnect_delay"])
             )
-            if self._restart_wait_timer >= restart_delay and wind_ok and not self.operator_stop and not self.service_mode and self._restart_block_timer <= 0.0:
+            if self._max_restarts_exceeded():
+                # Z72: max restarts exceeded → go to Shutdown (state 1)
+                self._enter_state(1)
+            elif self._restart_wait_timer >= restart_delay and wind_ok and not self.operator_stop and not self.service_mode and self._restart_block_timer <= 0.0:
                 self._enter_state(2)
         elif st == 4:
+            # Z72 Pre-Production: converter to standby, yaw to auto
             if not wind_ok:
                 self._request_stop("normal", "low_wind")
             elif self._state_timer >= 3.0:
                 self._enter_state(5)
         elif st == 5:
+            # Z72 Start Production: blades to startup (30°), then to work when rotor > 3.5 rpm
             self._sync_progress = min(1.0, self._state_timer / 7.0)
             if not wind_ok:
                 self._request_stop("normal", "low_wind")
-            elif self.rotor_speed >= max(2.5, self.rotor_model.rated_rpm * 0.35) and self._state_timer >= 7.0 and sync_ok:
+            # Z72: rotor > 3.5 rpm → blades move to work; rotor > 6.0 rpm → converter production
+            elif self.rotor_speed >= 3.5 and self._state_timer >= 7.0 and sync_ok:
                 self._enter_state(6)
         elif st == 6:
             self._sync_progress = 1.0
@@ -489,42 +571,63 @@ class TurbinePhysicsModel:
             elif wind_speed > s.cut_out_speed:
                 self._request_stop("emergency", "cut_out")
         elif st == 7:
+            # Z72 Emergency Stop: blades go to vane (86°) via emergency pitch
             if self.rotor_speed < 0.3 and self._state_timer >= 4.0:
                 self._stop_requested = False
                 self._enter_state(3)
         elif st == 8:
-            if wind_ok and self._restart_block_timer <= 0.0:
+            if wind_ok and self._restart_block_timer <= 0.0 and not self._max_restarts_exceeded():
+                self._restart_timestamps.append(self._sim_time)
                 self._enter_state(4)
             else:
                 self._enter_state(3)
         elif st == 9:
+            # Z72 Normal Stop: blades to vane via servo
             if self.rotor_speed < 0.3 and self._state_timer >= 12.0:
                 self._stop_requested = False
                 self._enter_state(1)
 
     def _calc_pitch(self, wind_speed: float, is_producing: bool, dt: float):
+        """Z72 pitch control with real setpoints from OEM manual.
+
+        Angles:  vane=86°, startup=30°, work=-1°
+        Emergency pitch: battery-driven DC motor, min 5°/s
+        Normal servo: DC servo motor per blade
+        """
         s = self.spec
         max_rate = 8.0 * self._individuality["pitch_response_scale"]
 
         if self.tur_state == 7:
-            target = 88.0
-            max_rate = 18.0
+            # Z72 Emergency: batteries drive blades to vane (86°)
+            target = s.pitch_vane
+            max_rate = max(s.pitch_emergency_rate, 18.0)  # emergency pitch speed
         elif self.tur_state == 9:
-            target = 90.0
+            # Z72 Normal Stop: servo drives blades to vane (86°)
+            target = s.pitch_vane
             max_rate = 10.0
         elif self.tur_state == 4:
-            target = 72.0
+            # Z72 Pre-Production: blades stay near vane, preparing
+            target = s.pitch_vane - 10.0  # ~76°, slight move from vane
             max_rate = 6.0
         elif self.tur_state == 5:
-            target = max(2.0, 65.0 - self._sync_progress * 60.0)
+            # Z72 Start Production: blades go to startup (30°), then to work as rotor spins up
+            if self._sync_progress < 0.4:
+                target = s.pitch_startup  # 30°
+            else:
+                # Transition from startup to work position
+                target = s.pitch_startup - self._sync_progress * (s.pitch_startup - s.pitch_work)
             max_rate = 7.5
         elif not is_producing:
-            target = 90.0
+            # Z72 Standby/Shutdown: blades at vane
+            target = s.pitch_vane
         elif wind_speed < s.rated_speed:
-            target = 0.0
+            # Z72 Region 2 (partial load): pitch at work position for max Cp
+            target = s.pitch_work  # -1°
         else:
+            # Z72 Region 3 (full load): pitch to limit power
             excess_wind = wind_speed - s.rated_speed
-            target = min(30.0, excess_wind * 2.0 + excess_wind ** 2 * 0.1)
+            target = max(s.pitch_work, s.pitch_work + excess_wind * 2.0 + excess_wind ** 2 * 0.1)
+            target = min(30.0, target)
 
         active_curtail = self.curtailment_kw if self.curtailment_kw is not None else s.curtailment_kw
         if is_producing and active_curtail is not None and active_curtail < s.rated_power_kw:
@@ -609,8 +712,8 @@ class TurbinePhysicsModel:
     def reset(self):
         self.tur_state = 1
         self.rotor_speed = 0.0
-        self.pitch_angle = 90.0
-        self._pitch_bl = [90.0, 90.0, 90.0]
+        self.pitch_angle = self.spec.pitch_vane  # Z72: vane position (86°)
+        self._pitch_bl = [self.spec.pitch_vane] * 3
         self._sim_time = 0.0
         self._generated_power_kw = 0.0
         self._generator_speed = 0.0
@@ -628,7 +731,7 @@ class TurbinePhysicsModel:
         self._grid_phase = self._rng.uniform(0.0, math.tau)
         self._grid_local_phase = self._rng.uniform(0.0, math.tau)
         self._grid_voltage_ref = self.spec.nominal_voltage
-        self._grid_frequency_ref = 50.0
+        self._grid_frequency_ref = self.spec.grid_frequency_nominal
         self._grid_normal_trip_accum = 0.0
         self._grid_emergency_trip_accum = 0.0
         self.operator_stop = False
@@ -667,7 +770,7 @@ class TurbinePhysicsModel:
                                grid_voltage_ref: Optional[float] = None):
         self._grid_phase = (self._grid_phase + dt * 0.03) % math.tau
         self._grid_local_phase = (self._grid_local_phase + dt * 0.05) % math.tau
-        freq_base = 50.0 + 0.08 * math.sin(self._grid_phase) + self._rng.normal(0.0, 0.01)
+        freq_base = self.spec.grid_frequency_nominal + 0.08 * math.sin(self._grid_phase) + self._rng.normal(0.0, 0.01)
         volt_base = self.spec.nominal_voltage + self._individuality["grid_voltage_bias"] + 6.0 * math.sin(self._grid_phase * 0.7 + 0.4) + self._rng.normal(0.0, 0.8)
         farm_freq = grid_frequency_ref if grid_frequency_ref is not None else freq_base
         farm_volt = grid_voltage_ref if grid_voltage_ref is not None else volt_base
@@ -685,7 +788,7 @@ class TurbinePhysicsModel:
         self._grid_voltage_ref = farm_volt + local_volt
 
     def _get_grid_derate(self) -> float:
-        freq_dev = abs(self._grid_frequency_ref - 50.0)
+        freq_dev = abs(self._grid_frequency_ref - self.spec.grid_frequency_nominal)
         volt_dev = abs(self._grid_voltage_ref - self.spec.nominal_voltage)
         sensitivity = self._individuality["grid_derate_sensitivity"]
         freq_scale = 1.0 if freq_dev < 0.15 else max(0.72, 1.0 - (freq_dev - 0.15) * 0.45 * sensitivity)

--- a/simulator/physics/yaw_model.py
+++ b/simulator/physics/yaw_model.py
@@ -15,17 +15,18 @@ class YawModel:
         self.yaw_angle = 270.0
         self.cable_windup = 0.0
 
-        self.dead_band = 8.0
-        self.yaw_rate = 0.4
-        self.activation_delay = 60.0
-        self.post_hold_time = 30.0
-        self.unwind_threshold = 2.5
+        # Z72 OEM values
+        self.dead_band = 15.0             # Z72: auto yaw start outside [-15°, +15°]
+        self.yaw_rate = 0.5               # Z72: nominal yaw speed 0.5 deg/s
+        self.activation_delay = 60.0      # seconds before yaw activates
+        self.post_hold_time = 30.0        # seconds to hold after alignment within [-2°, +2°]
+        self.unwind_threshold = 2.0       # Z72: cable twist > 2 turns → unwind
 
         self._error_timer = 0.0
         self._hold_timer = 0.0
         self._is_yawing = False
         self._is_unwinding = False
-        self._brake_pressure = 160.0
+        self._brake_pressure = 210.0      # Z72: high friction = 210 bar
         self._yaw_command_filter = 0.0
 
     def step(self, wind_direction: float, is_producing: bool, dt: float) -> Dict[str, float]:
@@ -35,7 +36,7 @@ class YawModel:
             self._is_yawing = False
             self._error_timer = 0.0
             self._yaw_command_filter = 0.0
-            self._brake_pressure = min(180.0, self._brake_pressure + 3.0 * dt)
+            self._brake_pressure = min(210.0, self._brake_pressure + 3.0 * dt)  # Z72: 210 bar = brakes dropped
             return self._output(error)
 
         if abs(self.cable_windup) > self.unwind_threshold:
@@ -44,7 +45,7 @@ class YawModel:
             unwind_dir = -1.0 if self.cable_windup > 0 else 1.0
             self.yaw_angle = (self.yaw_angle + unwind_dir * self.yaw_rate * dt) % 360
             self.cable_windup += unwind_dir * self.yaw_rate * dt / 360
-            self._brake_pressure = max(80.0, self._brake_pressure - 5.0 * dt)
+            self._brake_pressure = max(20.0, self._brake_pressure - 8.0 * dt)  # Z72: 20 bar = low friction
             if abs(self.cable_windup) < 0.3:
                 self._is_unwinding = False
             return self._output(error, yawing=True)
@@ -69,10 +70,10 @@ class YawModel:
             self.yaw_angle = (self.yaw_angle + step_angle) % 360
             self.cable_windup += step_angle / 360
             self.cable_windup = max(-4.0, min(4.0, self.cable_windup))
-            self._brake_pressure = max(80.0, self._brake_pressure - 5.0 * dt)
+            self._brake_pressure = max(20.0, self._brake_pressure - 8.0 * dt)  # Z72: lifted for yaw
         else:
             self._yaw_command_filter *= max(0.0, 1.0 - dt / 2.0)
-            self._brake_pressure = min(180.0, self._brake_pressure + 3.0 * dt)
+            self._brake_pressure = min(210.0, self._brake_pressure + 3.0 * dt)  # Z72: 210 bar = dropped
 
         return self._output(error, self._is_yawing)
 


### PR DESCRIPTION
Based on Harakosan Z72 User Manual (HE-0378-R03) and PLC OPC tag list:

Turbine specifications (now default):
- Rated power: 2000 kW (was 5000), rotor: 70.65m (was 126m)
- Direct-drive PMSG 60-pole at 3.5kV (no gearbox)
- Cut-in 3 m/s, rated 13 m/s, cut-out 25 m/s, max RPM 22.5
- 60Hz grid system

State machine improvements:
- Overspeed protection: software 26.5 RPM, hardware 28.5 RPM
- Max restarts per hour tracking (default 3, per Z72 event logic)
- Direct-drive sync check: rotor > 6 RPM (converter-decoupled)
- Correct state transitions matching Z72 OEM sequence

Pitch model calibrated to Z72 OEM angles:
- Vane (feathered): 86° (was 90°)
- Startup position: 30° (was 72°)
- Work position: -1° (was 0°)
- Emergency pitch rate: min 5°/s (battery-driven)

Yaw model calibrated:
- Dead band: 15° (Z72: auto yaw outside [-15°, +15°])
- Brake pressure: 210 bar dropped / 20 bar lifted / 0 bar none
- Cable unwind threshold: 2.0 turns
- Yaw rate: 0.5 deg/s

Temperature thresholds from OEM alarm list:
- Gen stator: alarm 140°C, trip 150°C
- Gen bearing: alarm 85°C, trip 95°C
- Nacelle/rotor cabinet: alarm 45°C, trip 50°C

Power curve rescaled for 2MW Z72 profile.

https://claude.ai/code/session_01DmcazBF4dujPKPjrXkNEJ4