### PR TITLE
fix: speed up wind profile transition (300s → 30s), add API connectio…

### DIFF
--- a/frontend/components/SettingsPage.tsx
+++ b/frontend/components/SettingsPage.tsx
@@ -46,11 +46,17 @@ const SettingsPage: React.FC<SettingsPageProps> = ({ settings, onSave, lang = 'z
     const [customGrid, setCustomGrid] = useState({ frequency: '50.0', voltage: '690' });
     const [gridMsg, setGridMsg] = useState('');
 
+    const [apiConnected, setApiConnected] = useState<boolean | null>(null);
+
     const refreshWindStatus = () => {
-        fetch(`${API_BASE}/api/config/wind`).then(r => r.json()).then(setWindStatus).catch(() => {});
+        fetch(`${API_BASE}/api/config/wind`)
+            .then(r => { setApiConnected(true); return r.json(); })
+            .then(setWindStatus)
+            .catch(() => { setApiConnected(false); });
     };
     const refreshGridStatus = () => {
-        fetch(`${API_BASE}/api/config/grid`).then(r => r.json()).then(setGridStatus).catch(() => {});
+        fetch(`${API_BASE}/api/config/grid`)
+            .then(r => r.json()).then(setGridStatus).catch(() => {});
     };
 
     useEffect(() => {
@@ -65,28 +71,42 @@ const SettingsPage: React.FC<SettingsPageProps> = ({ settings, onSave, lang = 'z
 
     const handleSetProfile = async (profile: string) => {
         setWindProfile(profile);
-        await fetch(`${API_BASE}/api/config/wind`, {
-            method: 'POST', headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ profile }),
-        });
-        setWindMsg(lang === 'zh' ? `已切換: ${profile}` : `Switched to: ${profile}`);
+        try {
+            const res = await fetch(`${API_BASE}/api/config/wind`, {
+                method: 'POST', headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ profile }),
+            });
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            setWindMsg(lang === 'zh' ? `已切換: ${profile}` : `Switched to: ${profile}`);
+            setApiConnected(true);
+        } catch (e) {
+            setWindMsg(lang === 'zh' ? `無法設定風況 (${API_BASE} 無回應)` : `Failed to set wind (${API_BASE} not responding)`);
+            setApiConnected(false);
+        }
         refreshWindStatus();
-        setTimeout(() => setWindMsg(''), 3000);
+        setTimeout(() => setWindMsg(''), 5000);
     };
 
     const handleSetCustomWind = async () => {
-        await fetch(`${API_BASE}/api/config/wind`, {
-            method: 'POST', headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                windSpeed: parseFloat(customWind.speed) || null,
-                windDirection: parseFloat(customWind.direction) || null,
-                ambientTemp: parseFloat(customWind.temp) || null,
-                turbulence: parseFloat(customWind.turbulence) || null,
-            }),
-        });
-        setWindMsg(lang === 'zh' ? '已套用自訂風況' : 'Custom wind applied');
+        try {
+            const res = await fetch(`${API_BASE}/api/config/wind`, {
+                method: 'POST', headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    windSpeed: parseFloat(customWind.speed) || null,
+                    windDirection: parseFloat(customWind.direction) || null,
+                    ambientTemp: parseFloat(customWind.temp) || null,
+                    turbulence: parseFloat(customWind.turbulence) || null,
+                }),
+            });
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            setWindMsg(lang === 'zh' ? '已套用自訂風況' : 'Custom wind applied');
+            setApiConnected(true);
+        } catch (e) {
+            setWindMsg(lang === 'zh' ? `無法設定風況 (${API_BASE} 無回應)` : `Failed to set wind (${API_BASE} not responding)`);
+            setApiConnected(false);
+        }
         refreshWindStatus();
-        setTimeout(() => setWindMsg(''), 3000);
+        setTimeout(() => setWindMsg(''), 5000);
     };
 
     const handleSetGridProfile = async (profile: string) => {
@@ -441,6 +461,20 @@ const SettingsPage: React.FC<SettingsPageProps> = ({ settings, onSave, lang = 'z
                                 </button>
 
                                 {specMsg && <span className="ml-3 text-sm text-cyan-300">{specMsg}</span>}
+                            </div>
+                        )}
+
+                        {/* API Connection Warning */}
+                        {apiConnected === false && (
+                            <div className="bg-red-900/30 border border-red-500/50 rounded-md p-4 mb-4">
+                                <div className="text-red-300 font-semibold">
+                                    {lang === 'zh' ? '無法連線到後端 API' : 'Cannot connect to backend API'}
+                                </div>
+                                <div className="text-red-400/80 text-sm mt-1">
+                                    {lang === 'zh'
+                                        ? `請確認後端伺服器正在運行。目前嘗試連線: ${API_BASE}`
+                                        : `Please ensure the backend server is running. Trying: ${API_BASE}`}
+                                </div>
                             </div>
                         )}
 

--- a/wind_model.py
+++ b/wind_model.py
@@ -115,7 +115,7 @@ class WindEnvironmentModel:
         self._transition_from: Optional[float] = None
         self._transition_to: Optional[float] = None
         self._transition_start: Optional[float] = None
-        self._transition_duration: float = 300.0  # 5 minutes default ramp
+        self._transition_duration: float = 30.0  # 30 seconds default ramp
         self._elapsed_real = 0.0  # real elapsed seconds
 
         # Weather system state (for deterministic long-term)
@@ -192,7 +192,7 @@ class WindEnvironmentModel:
             self._transition_from = current
             self._transition_to = 18.0 if profile == 'ramp_up' else 3.0
             self._transition_start = self._elapsed_real
-            self._transition_duration = 600.0  # 10 minute ramp
+            self._transition_duration = 120.0  # 2 minute ramp
             return
 
         if profile in profiles:
@@ -235,9 +235,9 @@ class WindEnvironmentModel:
         elif self._active_profile in ('ramp_up', 'ramp_down') and self._profile_start_time:
             elapsed = (timestamp - self._profile_start_time).total_seconds()
             if self._active_profile == 'ramp_up':
-                base = 3.0 + min(15.0, elapsed / 600.0 * 15.0)
+                base = 3.0 + min(15.0, elapsed / 120.0 * 15.0)
             else:
-                base = max(3.0, 18.0 - elapsed / 600.0 * 15.0)
+                base = max(3.0, 18.0 - elapsed / 120.0 * 15.0)
         elif self._override_wind_speed is not None:
             base = self._override_wind_speed
         else:


### PR DESCRIPTION
…n indicator

- Wind profile transition ramp reduced from 5 minutes to 30 seconds so profile changes take effect visibly within seconds
- Ramp up/down profiles shortened from 10 minutes to 2 minutes
- SettingsPage now shows red banner when API connection fails, helping diagnose port mismatch issues
- Wind/custom profile buttons show error messages on failure instead of silently failing

https://claude.ai/code/session_01FcbgpBxBCszucTPgJ4zhar