### PR TITLE
feat: multi-farm management with independent DB per wind farm

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -14,6 +14,7 @@ import WorkOrderDetailModal from './components/WorkOrderDetailModal';
 import SettingsPage from './components/SettingsPage';
 import { useSettings } from './hooks/useSettings';
 import HistoryPage from './components/HistoryPage';
+import FarmSelector from './components/FarmSelector';
 
 const NavButton = ({ isActive, onClick, children }: {isActive: boolean, onClick: ()=>void, children: React.ReactNode}) => (
     <button
@@ -183,6 +184,7 @@ const App: React.FC = () => {
                 <span className={`font-bold ${getStatusColorClass(farmStatus)}`}>{farmStatus}</span>
               </div>
             </div>
+            <FarmSelector lang={lang} />
             {/* Language toggle */}
             <button onClick={() => setLang(lang === 'zh' ? 'en' : 'zh')}
               className="text-xs px-2 py-1 rounded border border-gray-600 text-gray-400 hover:text-white hover:border-gray-400 transition-colors"

--- a/frontend/components/FarmSelector.tsx
+++ b/frontend/components/FarmSelector.tsx
@@ -1,0 +1,135 @@
+import React, { useState, useEffect, useRef } from 'react';
+
+const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8100';
+
+interface Farm {
+  farm_id: string;
+  name: string;
+  turbine_count: number;
+  is_active: boolean;
+  location: string;
+  description: string;
+  created_at: string;
+  turbine_spec: Record<string, unknown>;
+}
+
+interface Props {
+  lang: string;
+}
+
+const FarmSelector: React.FC<Props> = ({ lang }) => {
+  const [farms, setFarms] = useState<Farm[]>([]);
+  const [activeFarmId, setActiveFarmId] = useState<string | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [switching, setSwitching] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const ui = (en: string, zh: string) => lang === 'zh' ? zh : en;
+
+  useEffect(() => {
+    fetchFarms();
+  }, []);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const fetchFarms = async () => {
+    try {
+      const res = await fetch(`${API_BASE}/api/farms`);
+      if (!res.ok) return;
+      const data = await res.json();
+      setFarms(data.farms || []);
+      setActiveFarmId(data.active_farm_id);
+    } catch {
+      // Farm API not available yet — silently ignore
+    }
+  };
+
+  const switchFarm = async (farmId: string) => {
+    if (farmId === activeFarmId || switching) return;
+    setSwitching(true);
+    try {
+      const res = await fetch(`${API_BASE}/api/farms/${farmId}/activate`, { method: 'POST' });
+      if (res.ok) {
+        setActiveFarmId(farmId);
+        setIsOpen(false);
+        window.location.reload();
+      }
+    } catch {
+      // ignore
+    } finally {
+      setSwitching(false);
+    }
+  };
+
+  const activeFarm = farms.find(f => f.farm_id === activeFarmId);
+
+  if (farms.length === 0) return null;
+
+  const ratedPower = activeFarm?.turbine_spec?.rated_power_kw as number | undefined;
+  const label = activeFarm
+    ? `${activeFarm.name}${ratedPower ? ` (${(ratedPower / 1000).toFixed(1)}MW)` : ''}`
+    : ui('Select Farm', '選擇風場');
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center space-x-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium border border-gray-600 text-gray-300 hover:text-white hover:border-gray-400 transition-colors bg-gray-800/60"
+        title={ui('Switch Wind Farm', '切換風場')}
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-4 h-4">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 21h19.5m-18-18v18m10.5-18v18m6-13.5V21M6.75 6.75h.75m-.75 3h.75m-.75 3h.75m3-6h.75m-.75 3h.75m-.75 3h.75M6.75 21v-3.375c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21M3 3h12m-.75 4.5H21m-3.75 0h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008z" />
+        </svg>
+        <span className="hidden lg:inline max-w-[140px] truncate">{label}</span>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-3 h-3">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div className="absolute top-full right-0 mt-1 w-72 bg-gray-800 border border-gray-600 rounded-lg shadow-xl z-[100] overflow-hidden">
+          <div className="px-3 py-2 border-b border-gray-700 text-xs text-gray-400 font-medium">
+            {ui('Wind Farms', '風場專案')}
+          </div>
+          <div className="max-h-64 overflow-y-auto">
+            {farms.map(farm => {
+              const power = farm.turbine_spec?.rated_power_kw as number | undefined;
+              return (
+                <button
+                  key={farm.farm_id}
+                  onClick={() => switchFarm(farm.farm_id)}
+                  disabled={switching}
+                  className={`w-full text-left px-3 py-2.5 flex items-center justify-between hover:bg-gray-700/50 transition-colors ${
+                    farm.farm_id === activeFarmId ? 'bg-cyan-500/10 border-l-2 border-cyan-400' : 'border-l-2 border-transparent'
+                  }`}
+                >
+                  <div>
+                    <div className="text-sm text-white font-medium">{farm.name}</div>
+                    <div className="text-xs text-gray-400">
+                      {farm.turbine_count} {ui('turbines', '台風機')}
+                      {power ? ` | ${(power / 1000).toFixed(1)} MW` : ''}
+                      {farm.location ? ` | ${farm.location}` : ''}
+                    </div>
+                  </div>
+                  {farm.farm_id === activeFarmId && (
+                    <span className="text-cyan-400 text-xs font-medium">{ui('Active', '使用中')}</span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default FarmSelector;

--- a/server/app.py
+++ b/server/app.py
@@ -7,10 +7,12 @@ from fastapi.middleware.cors import CORSMiddleware
 from typing import List
 
 from server.models import DataSourceConfig, DataSourceMode, SimulationConfig
+from server.farm_registry import FarmRegistry
 from server.data_broker import DataBroker
 
-# Global broker instance
-broker = DataBroker()
+# Global instances
+farm_registry = FarmRegistry()
+broker = DataBroker(farm_registry=farm_registry)
 
 # WebSocket connection manager
 ws_clients: List[WebSocket] = []
@@ -19,11 +21,36 @@ ws_clients: List[WebSocket] = []
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Manage application lifecycle: start simulator and Modbus on startup, clean up on shutdown."""
-    # Startup: start simulator
+    # Migrate legacy DB if it exists
+    from pathlib import Path
+    legacy_path = Path(__file__).parent.parent / "wind_farm_data.db"
+    migrated = farm_registry.migrate_legacy_db(legacy_path)
+    if migrated:
+        print(f"[Server] Migrated legacy database to farm '{migrated}'")
+
+    # Determine active farm and its config
+    farm_id = farm_registry.ensure_default_farm()
+    farm = farm_registry.get_farm(farm_id)
+    turbine_count = farm.turbine_count if farm else 14
+    print(f"[Server] Active farm: {farm_id} ({turbine_count} turbines)")
+
+    # Startup: start simulator with active farm
     config = DataSourceConfig(mode=DataSourceMode.SIMULATION)
-    sim_config = SimulationConfig(turbineCount=14)
+    sim_config = SimulationConfig(turbineCount=turbine_count)
     broker.start(config, sim_config)
-    print("[Server] Wind farm simulator started with 14 turbines")
+
+    # Apply farm turbine spec if defined
+    if farm and farm.turbine_spec and broker.simulator:
+        from simulator.physics.turbine_physics import TurbineSpec
+        try:
+            spec = TurbineSpec.from_dict(farm.turbine_spec)
+            for model in broker.simulator.turbines.values():
+                model.update_spec(spec)
+            print("[Server] Applied turbine spec from farm config")
+        except Exception as e:
+            print(f"[Server] Warning: could not apply farm spec: {e}")
+
+    print(f"[Server] Wind farm simulator started with {turbine_count} turbines")
 
     # Auto-start Modbus TCP server
     if broker.simulator:
@@ -72,6 +99,7 @@ from server.routers.i18n import router as i18n_router  # noqa: E402
 from server.routers.modbus import router as modbus_router  # noqa: E402
 from server.routers.control import router as control_router  # noqa: E402
 from server.routers.maintenance import router as maintenance_router  # noqa: E402
+from server.routers.farms import router as farms_router  # noqa: E402
 
 app.include_router(turbines_router)
 app.include_router(config_router)
@@ -81,6 +109,7 @@ app.include_router(i18n_router)
 app.include_router(modbus_router)
 app.include_router(control_router)
 app.include_router(maintenance_router)
+app.include_router(farms_router)
 
 
 @app.get("/api/health")
@@ -90,6 +119,7 @@ async def health():
         "status": "ok",
         "mode": broker.mode.value,
         "turbineCount": len(broker.turbine_ids),
+        "activeFarmId": broker.active_farm_id,
     }
 
 

--- a/server/data_broker.py
+++ b/server/data_broker.py
@@ -12,6 +12,7 @@ from server.models import (
     DataSourceConfig, SimulationConfig, FarmStatus,
 )
 from server.storage import Storage
+from server.farm_registry import FarmRegistry
 from simulator.engine import WindFarmSimulator
 
 
@@ -230,8 +231,10 @@ class DataBroker:
     # Snapshot window: seconds of 1s data to capture before/after event
     SNAPSHOT_WINDOW_S = 600  # 10 minutes
 
-    def __init__(self):
+    def __init__(self, farm_registry: Optional[FarmRegistry] = None):
         self.mode = DataSourceMode.SIMULATION
+        self.farm_registry = farm_registry or FarmRegistry()
+        self._active_farm_id: Optional[str] = None
         self.storage = Storage()
         self.simulator: Optional[WindFarmSimulator] = None
         self._sim_config = SimulationConfig()
@@ -256,6 +259,44 @@ class DataBroker:
         self._maintenance_thread: Optional[threading.Thread] = None
         self._maintenance_running = False
 
+    def _init_farm_storage(self):
+        """Point storage at the active farm's database."""
+        farm_id = self._active_farm_id or self.farm_registry.get_active_farm_id()
+        if not farm_id:
+            farm_id = self.farm_registry.ensure_default_farm()
+        self._active_farm_id = farm_id
+        db_path = str(self.farm_registry.get_farm_db_path(farm_id))
+        self.storage = Storage(db_path=db_path)
+
+    def switch_farm(self, farm_id: str) -> bool:
+        """Switch the active wind farm. Stops current simulator, swaps DB, restarts."""
+        farm = self.farm_registry.get_farm(farm_id)
+        if not farm:
+            return False
+        self.stop()
+        self.farm_registry.set_active_farm(farm_id)
+        self._active_farm_id = farm_id
+        self._init_farm_storage()
+
+        from simulator.physics.turbine_physics import TurbineSpec
+        if farm.turbine_spec:
+            spec = TurbineSpec.from_dict(farm.turbine_spec)
+        else:
+            spec = TurbineSpec()
+
+        self._sim_config = SimulationConfig(turbineCount=farm.turbine_count)
+        self.start()
+
+        if self.simulator:
+            for model in self.simulator.turbines.values():
+                model.update_spec(spec)
+
+        return True
+
+    @property
+    def active_farm_id(self) -> Optional[str]:
+        return self._active_farm_id
+
     def start(self, config: Optional[DataSourceConfig] = None,
               sim_config: Optional[SimulationConfig] = None):
         """Start the data broker in simulation or OPC mode and launch background maintenance."""
@@ -263,6 +304,9 @@ class DataBroker:
             self._sim_config = sim_config
         if config:
             self.mode = config.mode
+
+        if self._active_farm_id is None:
+            self._init_farm_storage()
 
         if self.mode == DataSourceMode.SIMULATION:
             self._start_simulator()

--- a/server/farm_registry.py
+++ b/server/farm_registry.py
@@ -1,0 +1,317 @@
+"""
+Wind Farm Registry — manages multiple independent wind farm projects.
+
+Each farm has its own SQLite database file under data/farms/{farm_id}/.
+A global metadata DB (data/farms.db) tracks all farms and the active farm.
+"""
+
+import json
+import os
+import shutil
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+DATA_DIR = Path(os.environ.get(
+    "FARM_DATA_DIR",
+    str(Path(__file__).parent.parent / "data"),
+))
+FARMS_DB = DATA_DIR / "farms.db"
+FARMS_DIR = DATA_DIR / "farms"
+
+LEGACY_DB_NAME = "wind_farm_data.db"
+
+
+@dataclass
+class FarmConfig:
+    """Serializable wind farm project definition."""
+    farm_id: str
+    name: str
+    turbine_count: int = 14
+    turbine_spec: Dict = field(default_factory=dict)
+    wind_profile: Dict = field(default_factory=dict)
+    grid_profile: Dict = field(default_factory=dict)
+    layout: Dict = field(default_factory=dict)
+    location: str = ""
+    description: str = ""
+    created_at: str = ""
+    last_active_at: str = ""
+
+    def to_dict(self) -> dict:
+        return {k: getattr(self, k) for k in self.__dataclass_fields__}
+
+    @classmethod
+    def from_row(cls, row: sqlite3.Row) -> "FarmConfig":
+        return cls(
+            farm_id=row["farm_id"],
+            name=row["name"],
+            turbine_count=row["turbine_count"],
+            turbine_spec=json.loads(row["turbine_spec_json"] or "{}"),
+            wind_profile=json.loads(row["wind_profile_json"] or "{}"),
+            grid_profile=json.loads(row["grid_profile_json"] or "{}"),
+            layout=json.loads(row["layout_json"] or "{}"),
+            location=row["location"] or "",
+            description=row["description"] or "",
+            created_at=row["created_at"] or "",
+            last_active_at=row["last_active_at"] or "",
+        )
+
+
+class FarmRegistry:
+    """Manages the global farm list and provides paths to per-farm databases."""
+
+    def __init__(self, data_dir: Path = DATA_DIR):
+        self._data_dir = data_dir
+        self._farms_dir = data_dir / "farms"
+        self._farms_db = data_dir / "farms.db"
+        self._farms_dir.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    def _get_conn(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self._farms_db))
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_db(self):
+        conn = self._get_conn()
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS farms (
+                farm_id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                turbine_count INTEGER NOT NULL DEFAULT 14,
+                turbine_spec_json TEXT,
+                wind_profile_json TEXT,
+                grid_profile_json TEXT,
+                layout_json TEXT,
+                location TEXT,
+                description TEXT,
+                created_at TEXT NOT NULL,
+                last_active_at TEXT,
+                is_active INTEGER NOT NULL DEFAULT 0
+            )
+        """)
+        conn.commit()
+        conn.close()
+
+    # ── CRUD ────────────────────────────────────────────────────────────
+
+    def create_farm(self, farm_id: str, name: str,
+                    turbine_count: int = 14,
+                    turbine_spec: Optional[Dict] = None,
+                    wind_profile: Optional[Dict] = None,
+                    grid_profile: Optional[Dict] = None,
+                    layout: Optional[Dict] = None,
+                    location: str = "",
+                    description: str = "") -> FarmConfig:
+        """Create a new wind farm project with its own database directory."""
+        farm_dir = self._farms_dir / farm_id
+        farm_dir.mkdir(parents=True, exist_ok=True)
+
+        now = datetime.now().isoformat()
+        conn = self._get_conn()
+        conn.execute("""
+            INSERT INTO farms (farm_id, name, turbine_count,
+                               turbine_spec_json, wind_profile_json,
+                               grid_profile_json, layout_json,
+                               location, description, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """, (
+            farm_id, name, turbine_count,
+            json.dumps(turbine_spec or {}),
+            json.dumps(wind_profile or {}),
+            json.dumps(grid_profile or {}),
+            json.dumps(layout or {}),
+            location, description, now,
+        ))
+        conn.commit()
+        conn.close()
+
+        config_path = farm_dir / "config.json"
+        cfg = FarmConfig(
+            farm_id=farm_id, name=name, turbine_count=turbine_count,
+            turbine_spec=turbine_spec or {}, wind_profile=wind_profile or {},
+            grid_profile=grid_profile or {}, layout=layout or {},
+            location=location, description=description, created_at=now,
+        )
+        config_path.write_text(json.dumps(cfg.to_dict(), indent=2, ensure_ascii=False))
+        return cfg
+
+    def get_farm(self, farm_id: str) -> Optional[FarmConfig]:
+        conn = self._get_conn()
+        row = conn.execute("SELECT * FROM farms WHERE farm_id = ?", (farm_id,)).fetchone()
+        conn.close()
+        return FarmConfig.from_row(row) if row else None
+
+    def list_farms(self) -> List[FarmConfig]:
+        conn = self._get_conn()
+        rows = conn.execute("SELECT * FROM farms ORDER BY last_active_at DESC").fetchall()
+        conn.close()
+        return [FarmConfig.from_row(r) for r in rows]
+
+    def update_farm(self, farm_id: str, **kwargs) -> Optional[FarmConfig]:
+        """Update farm metadata. Accepts: name, location, description, turbine_spec, wind_profile, grid_profile."""
+        farm = self.get_farm(farm_id)
+        if not farm:
+            return None
+
+        conn = self._get_conn()
+        field_map = {
+            "name": "name",
+            "location": "location",
+            "description": "description",
+            "turbine_spec": "turbine_spec_json",
+            "wind_profile": "wind_profile_json",
+            "grid_profile": "grid_profile_json",
+            "layout": "layout_json",
+        }
+        for key, val in kwargs.items():
+            col = field_map.get(key)
+            if col and val is not None:
+                db_val = json.dumps(val) if col.endswith("_json") else val
+                conn.execute(f"UPDATE farms SET {col} = ? WHERE farm_id = ?", (db_val, farm_id))
+        conn.commit()
+        conn.close()
+
+        self._save_config_json(farm_id)
+        return self.get_farm(farm_id)
+
+    def delete_farm(self, farm_id: str) -> bool:
+        """Delete a farm and its data directory."""
+        farm = self.get_farm(farm_id)
+        if not farm:
+            return False
+        conn = self._get_conn()
+        conn.execute("DELETE FROM farms WHERE farm_id = ?", (farm_id,))
+        conn.commit()
+        conn.close()
+
+        farm_dir = self._farms_dir / farm_id
+        if farm_dir.exists():
+            shutil.rmtree(farm_dir)
+        return True
+
+    # ── Active farm ─────────────────────────────────────────────────────
+
+    def get_active_farm_id(self) -> Optional[str]:
+        conn = self._get_conn()
+        row = conn.execute("SELECT farm_id FROM farms WHERE is_active = 1").fetchone()
+        conn.close()
+        return row["farm_id"] if row else None
+
+    def set_active_farm(self, farm_id: str) -> bool:
+        farm = self.get_farm(farm_id)
+        if not farm:
+            return False
+        now = datetime.now().isoformat()
+        conn = self._get_conn()
+        conn.execute("UPDATE farms SET is_active = 0 WHERE is_active = 1")
+        conn.execute(
+            "UPDATE farms SET is_active = 1, last_active_at = ? WHERE farm_id = ?",
+            (now, farm_id),
+        )
+        conn.commit()
+        conn.close()
+        return True
+
+    # ── Paths ───────────────────────────────────────────────────────────
+
+    def get_farm_db_path(self, farm_id: str) -> Path:
+        """Return the SQLite database path for a specific farm."""
+        return self._farms_dir / farm_id / "wind_farm.db"
+
+    def get_farm_dir(self, farm_id: str) -> Path:
+        return self._farms_dir / farm_id
+
+    # ── Clone ───────────────────────────────────────────────────────────
+
+    def clone_farm(self, source_farm_id: str, new_farm_id: str,
+                   new_name: str, include_data: bool = False) -> Optional[FarmConfig]:
+        """Clone a farm config (and optionally its data) to a new farm."""
+        source = self.get_farm(source_farm_id)
+        if not source:
+            return None
+
+        new_farm = self.create_farm(
+            farm_id=new_farm_id, name=new_name,
+            turbine_count=source.turbine_count,
+            turbine_spec=source.turbine_spec,
+            wind_profile=source.wind_profile,
+            grid_profile=source.grid_profile,
+            layout=source.layout,
+            location=source.location,
+            description=f"Cloned from {source_farm_id}",
+        )
+
+        if include_data:
+            src_db = self.get_farm_db_path(source_farm_id)
+            dst_db = self.get_farm_db_path(new_farm_id)
+            if src_db.exists():
+                shutil.copy2(str(src_db), str(dst_db))
+
+        return new_farm
+
+    # ── Migration ───────────────────────────────────────────────────────
+
+    def migrate_legacy_db(self, legacy_db_path: Path) -> Optional[str]:
+        """Wrap an existing wind_farm_data.db as the 'legacy' farm.
+
+        Returns the farm_id if migration occurred, None if already done or no legacy DB.
+        """
+        if not legacy_db_path.exists():
+            return None
+
+        farm_id = "legacy"
+        if self.get_farm(farm_id):
+            return None
+
+        farm_dir = self._farms_dir / farm_id
+        farm_dir.mkdir(parents=True, exist_ok=True)
+
+        dst = farm_dir / "wind_farm.db"
+        shutil.move(str(legacy_db_path), str(dst))
+
+        self.create_farm(
+            farm_id=farm_id,
+            name="既有資料（Legacy）",
+            turbine_count=14,
+            turbine_spec={},
+            description="自動遷移自原始 wind_farm_data.db",
+        )
+        self.set_active_farm(farm_id)
+        return farm_id
+
+    # ── Helpers ──────────────────────────────────────────────────────────
+
+    def _save_config_json(self, farm_id: str):
+        farm = self.get_farm(farm_id)
+        if not farm:
+            return
+        config_path = self._farms_dir / farm_id / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(farm.to_dict(), indent=2, ensure_ascii=False))
+
+    def ensure_default_farm(self) -> str:
+        """Ensure at least one farm exists. Returns the active farm_id."""
+        active = self.get_active_farm_id()
+        if active:
+            return active
+
+        farms = self.list_farms()
+        if farms:
+            self.set_active_farm(farms[0].farm_id)
+            return farms[0].farm_id
+
+        from simulator.physics.turbine_physics import TurbineSpec
+        default_spec = TurbineSpec()
+        farm = self.create_farm(
+            farm_id="default_z72_2mw",
+            name="Z72-2000-MV 預設風場",
+            turbine_count=14,
+            turbine_spec=default_spec.to_dict(),
+            description="預設 14 台 Z72 直驅 2MW 風機",
+        )
+        self.set_active_farm(farm.farm_id)
+        return farm.farm_id

--- a/server/routers/farms.py
+++ b/server/routers/farms.py
@@ -1,0 +1,337 @@
+"""
+Wind Farm management API — CRUD, activate, clone, export.
+"""
+
+import io
+import json
+import re
+import zipfile
+from datetime import datetime
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import StreamingResponse
+
+router = APIRouter(prefix="/api/farms", tags=["farms"])
+
+
+def _get_registry():
+    from server.app import farm_registry
+    return farm_registry
+
+
+def _get_broker():
+    from server.app import broker
+    return broker
+
+
+def _sanitize_id(name: str) -> str:
+    """Convert a display name to a valid farm_id slug."""
+    s = re.sub(r"[^\w\s-]", "", name.lower())
+    s = re.sub(r"[\s]+", "_", s.strip())
+    return s[:60] or "farm"
+
+
+# ── List / Get ──────────────────────────────────────────────────────────
+
+@router.get("")
+async def list_farms():
+    """List all wind farm projects."""
+    reg = _get_registry()
+    farms = reg.list_farms()
+    active_id = reg.get_active_farm_id()
+    return {
+        "active_farm_id": active_id,
+        "farms": [f.to_dict() | {"is_active": f.farm_id == active_id} for f in farms],
+    }
+
+
+@router.get("/active")
+async def get_active_farm():
+    """Get the currently active wind farm."""
+    reg = _get_registry()
+    farm_id = reg.get_active_farm_id()
+    if not farm_id:
+        raise HTTPException(404, "No active farm")
+    farm = reg.get_farm(farm_id)
+    return farm.to_dict() | {"is_active": True}
+
+
+@router.get("/{farm_id}")
+async def get_farm(farm_id: str):
+    """Get details of a specific wind farm."""
+    farm = _get_registry().get_farm(farm_id)
+    if not farm:
+        raise HTTPException(404, f"Farm not found: {farm_id}")
+    active_id = _get_registry().get_active_farm_id()
+    return farm.to_dict() | {"is_active": farm_id == active_id}
+
+
+# ── Create ──────────────────────────────────────────────────────────────
+
+@router.post("")
+async def create_farm(body: dict):
+    """Create a new wind farm project.
+
+    Required: name
+    Optional: farm_id, turbine_count, preset, turbine_spec,
+              wind_profile, grid_profile, location, description
+    """
+    reg = _get_registry()
+    name = body.get("name")
+    if not name:
+        raise HTTPException(400, "name is required")
+
+    farm_id = body.get("farm_id") or _sanitize_id(name)
+    if reg.get_farm(farm_id):
+        raise HTTPException(409, f"Farm already exists: {farm_id}")
+
+    turbine_count = body.get("turbine_count", 14)
+    turbine_spec = body.get("turbine_spec", {})
+
+    preset_name = body.get("preset")
+    if preset_name:
+        from simulator.physics.turbine_physics import TURBINE_PRESETS
+        if preset_name not in TURBINE_PRESETS:
+            raise HTTPException(404, f"Unknown preset: {preset_name}. Available: {list(TURBINE_PRESETS.keys())}")
+        turbine_spec = TURBINE_PRESETS[preset_name].to_dict()
+
+    farm = reg.create_farm(
+        farm_id=farm_id,
+        name=name,
+        turbine_count=turbine_count,
+        turbine_spec=turbine_spec,
+        wind_profile=body.get("wind_profile", {}),
+        grid_profile=body.get("grid_profile", {}),
+        layout=body.get("layout", {}),
+        location=body.get("location", ""),
+        description=body.get("description", ""),
+    )
+    return {"status": "created", "farm": farm.to_dict()}
+
+
+# ── Update ──────────────────────────────────────────────────────────────
+
+@router.patch("/{farm_id}")
+async def update_farm(farm_id: str, body: dict):
+    """Update farm metadata (name, description, location, turbine_spec, etc.)."""
+    farm = _get_registry().update_farm(farm_id, **body)
+    if not farm:
+        raise HTTPException(404, f"Farm not found: {farm_id}")
+    return {"status": "updated", "farm": farm.to_dict()}
+
+
+# ── Delete ──────────────────────────────────────────────────────────────
+
+@router.delete("/{farm_id}")
+async def delete_farm(farm_id: str):
+    """Delete a wind farm and all its data. Requires confirmation."""
+    reg = _get_registry()
+    if reg.get_active_farm_id() == farm_id:
+        raise HTTPException(400, "Cannot delete the active farm. Switch to another farm first.")
+    ok = reg.delete_farm(farm_id)
+    if not ok:
+        raise HTTPException(404, f"Farm not found: {farm_id}")
+    return {"status": "deleted", "farm_id": farm_id}
+
+
+# ── Activate ────────────────────────────────────────────────────────────
+
+@router.post("/{farm_id}/activate")
+async def activate_farm(farm_id: str):
+    """Switch the simulator to this wind farm."""
+    b = _get_broker()
+    ok = b.switch_farm(farm_id)
+    if not ok:
+        raise HTTPException(404, f"Farm not found: {farm_id}")
+    farm = _get_registry().get_farm(farm_id)
+    return {"status": "activated", "farm": farm.to_dict()}
+
+
+# ── Clone ───────────────────────────────────────────────────────────────
+
+@router.post("/{farm_id}/clone")
+async def clone_farm(farm_id: str, body: dict):
+    """Clone a farm. Options: new_name (required), new_farm_id, include_data (bool)."""
+    reg = _get_registry()
+    new_name = body.get("new_name")
+    if not new_name:
+        raise HTTPException(400, "new_name is required")
+
+    new_id = body.get("new_farm_id") or _sanitize_id(new_name)
+    if reg.get_farm(new_id):
+        raise HTTPException(409, f"Farm already exists: {new_id}")
+
+    include_data = body.get("include_data", False)
+    farm = reg.clone_farm(farm_id, new_id, new_name, include_data=include_data)
+    if not farm:
+        raise HTTPException(404, f"Source farm not found: {farm_id}")
+    return {"status": "cloned", "farm": farm.to_dict()}
+
+
+# ── Export ──────────────────────────────────────────────────────────────
+
+@router.post("/{farm_id}/export")
+async def export_farm(farm_id: str, body: dict = {}):
+    """Export a farm as a zip file containing CSV data, events, and config.
+
+    Options:
+      format: "csv" (default)
+      include_events: true (default)
+    """
+    reg = _get_registry()
+    farm = reg.get_farm(farm_id)
+    if not farm:
+        raise HTTPException(404, f"Farm not found: {farm_id}")
+
+    from server.storage import Storage
+    db_path = str(reg.get_farm_db_path(farm_id))
+    if not Path(db_path).exists():
+        raise HTTPException(404, f"No data for farm: {farm_id}")
+
+    storage = Storage(db_path=db_path)
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("config.json", json.dumps(farm.to_dict(), indent=2, ensure_ascii=False))
+
+        history = storage.query_history(limit=500000)
+        if history:
+            import csv
+            csv_buf = io.StringIO()
+            writer = csv.DictWriter(csv_buf, fieldnames=history[0].keys())
+            writer.writeheader()
+            for row in history:
+                writer.writerow(dict(row))
+            zf.writestr("history.csv", csv_buf.getvalue())
+
+        include_events = body.get("include_events", True)
+        if include_events:
+            events = storage.query_events(limit=100000)
+            if events:
+                events_list = [dict(e) for e in events]
+                zf.writestr("events.json", json.dumps(events_list, indent=2, ensure_ascii=False))
+
+    buf.seek(0)
+    filename = f"{farm_id}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.zip"
+    return StreamingResponse(
+        buf,
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+# ── Dataset Generation ──────────────────────────────────────────────────
+
+@router.post("/{farm_id}/datasets/generate")
+async def generate_dataset(farm_id: str, body: dict):
+    """Generate a complete simulated dataset for a farm scenario.
+
+    This is the one-click "set up scenario → run → get data" endpoint.
+
+    Parameters:
+      duration_hours: hours of simulation (required, max 8760)
+      time_step: physics step in seconds (default 10)
+      wind_profile: {base_speed, turbulence_intensity, ...} (optional override)
+      grid_profile: {profile: "nominal"/"low_freq"/...} (optional)
+      fault_steps: [{offset_hours, scenario_id, turbine_id, severity_rate, initial_severity}]
+      output_format: "csv" (default)
+    """
+    reg = _get_registry()
+    farm = reg.get_farm(farm_id)
+    if not farm:
+        raise HTTPException(404, f"Farm not found: {farm_id}")
+
+    duration = body.get("duration_hours")
+    if not duration or duration <= 0:
+        raise HTTPException(400, "duration_hours is required and must be > 0")
+    if duration > 8760:
+        raise HTTPException(400, "Maximum 8760 hours (1 year)")
+
+    time_step = body.get("time_step", 10.0)
+    fault_steps = body.get("fault_steps", [])
+
+    # Use a temporary simulator + storage for this farm
+    from simulator.engine import WindFarmSimulator
+    from simulator.physics.turbine_physics import TurbineSpec
+    from server.storage import Storage
+
+    spec = TurbineSpec.from_dict(farm.turbine_spec) if farm.turbine_spec else TurbineSpec()
+    wind_cfg = body.get("wind_profile") or farm.wind_profile or {}
+    base_wind = wind_cfg.get("base_speed", 10.0)
+    turb_intensity = wind_cfg.get("turbulence_intensity", 0.12)
+
+    sim = WindFarmSimulator(
+        turbine_count=farm.turbine_count,
+        base_wind_speed=base_wind,
+        turbulence_intensity=turb_intensity,
+    )
+    for model in sim.turbines.values():
+        model.update_spec(spec)
+
+    # Use the farm's DB for storage
+    db_path = str(reg.get_farm_db_path(farm_id))
+    storage = Storage(db_path=db_path)
+    session_id = storage.create_session(
+        data_source="dataset_generation",
+        turbine_count=farm.turbine_count,
+        rated_power_kw=spec.rated_power_kw,
+        rotor_diameter_m=spec.rotor_diameter,
+        model_name=farm.name,
+        config={
+            "duration_hours": duration,
+            "time_step": time_step,
+            "wind_profile": wind_cfg,
+            "fault_steps": fault_steps,
+        },
+    )
+
+    # Sort fault steps by offset
+    sorted_faults = sorted(fault_steps, key=lambda s: s.get("offset_hours", 0))
+    fault_idx = 0
+
+    total_steps = int(duration * 3600 / time_step)
+    total_readings = 0
+
+    from datetime import timedelta
+    sim_time = datetime.now()
+
+    for i in range(total_steps):
+        if not sim._running:
+            break
+
+        sim_seconds = i * time_step
+
+        # Inject scheduled faults
+        while fault_idx < len(sorted_faults):
+            fs = sorted_faults[fault_idx]
+            offset_s = fs.get("offset_hours", 0) * 3600
+            if offset_s > sim_seconds:
+                break
+            sim.fault_engine.inject(
+                scenario_id=fs["scenario_id"],
+                turbine_id=fs.get("turbine_id", "WT001"),
+                severity_rate=fs.get("severity_rate", 0.001),
+                initial_severity=fs.get("initial_severity", 0.0),
+            )
+            fault_idx += 1
+
+        sim_time += timedelta(seconds=time_step)
+        readings = sim._run_one_step(sim_time, time_step)
+        total_readings += len(readings)
+        storage.store_readings(readings, session_id)
+
+    storage.run_downsampling()
+    storage.end_session(session_id)
+    sim.stop()
+
+    return {
+        "status": "ok",
+        "farm_id": farm_id,
+        "session_id": session_id,
+        "duration_hours": duration,
+        "time_step": time_step,
+        "total_readings": total_readings,
+        "fault_steps_executed": fault_idx,
+        "export_url": f"/api/farms/{farm_id}/export",
+    }


### PR DESCRIPTION
## Summary

Implements complete multi-wind-farm project management with independent database isolation per farm. Allows creating, switching, cloning, and generating datasets for different wind farm configurations without mixing their data.

## Motivation

Previously, changing turbine spec (e.g., 2MW → 5MW) caused historical data to be recorded in the same SQLite DB, mixing configurations. This PR introduces the concept of wind farm projects, each with its own independent data space and configuration.

## Architecture

```
data/
├── farms.db                      # Global farm metadata registry
└── farms/
    ├── legacy/
    │   ├── wind_farm.db          # Independent SQLite per farm
    │   └── config.json           # Farm configuration snapshot
    ├── taichung_5mw/
    │   ├── wind_farm.db
    │   └── config.json
    └── ...
```

## Key Changes

### New Modules
- `server/farm_registry.py` (317 lines) — `FarmRegistry` class managing farms metadata, per-farm DB paths, migration, and cloning
- `server/routers/farms.py` (337 lines) — 10 new REST endpoints for farm management
- `frontend/components/FarmSelector.tsx` (135 lines) — Header dropdown for switching active farm

### Modified
- `server/data_broker.py` — Accepts `FarmRegistry`, adds `switch_farm()`, uses per-farm Storage
- `server/app.py` — Auto-migrates legacy DB on startup, loads active farm config
- `frontend/App.tsx` — Embeds `FarmSelector` in header

## New API Endpoints (10)

| Method | Path | Purpose |
|--------|------|---------|
| GET | `/api/farms` | List all farms |
| POST | `/api/farms` | Create new farm (supports presets) |
| GET | `/api/farms/active` | Get currently active farm |
| GET | `/api/farms/{id}` | Get farm details |
| PATCH | `/api/farms/{id}` | Update metadata/spec |
| DELETE | `/api/farms/{id}` | Delete farm + data |
| POST | `/api/farms/{id}/activate` | Switch simulator to this farm |
| POST | `/api/farms/{id}/clone` | Clone (config or config+data) |
| POST | `/api/farms/{id}/export` | Download zip (CSV + events + config) |
| POST | `/api/farms/{id}/datasets/generate` | One-click scenario → simulate → store |

## Key Features

### 1. Automatic Legacy Migration
First startup detects existing `wind_farm_data.db` and wraps it as the `legacy` farm — no data loss.

### 2. One-Click Dataset Generation
```bash
POST /api/farms/{id}/datasets/generate
{
  "duration_hours": 168,
  "wind_profile": {"base_speed": 11, "turbulence_intensity": 0.14},
  "fault_steps": [
    {"offset_hours": 24, "scenario_id": "bearing_wear",
     "turbine_id": "WT003", "severity_rate": 0.0005}
  ]
}
```
Then `POST /api/farms/{id}/export` returns a zip with CSV + events + config for external analysis.

### 3. Farm Switching
Stops current simulator, swaps storage to the new farm's DB, restarts with the farm's turbine spec — no data mixing.

## Test Plan

- [ ] Fresh start: confirm `data/farms.db` created and default farm appears
- [ ] Legacy migration: existing `wind_farm_data.db` auto-wraps as `legacy` farm
- [ ] Create farm via `POST /api/farms` with preset `sg_8mw`
- [ ] Switch farms via frontend dropdown, verify simulator reloads with new spec
- [ ] Run `generate` then `export`, verify zip contents
- [ ] Delete non-active farm, confirm data directory removed
- [ ] Cannot delete active farm (returns 400)
- [ ] Clone farm with `include_data: true`, verify data copied
- [ ] Health endpoint returns `activeFarmId`

## Notes

- Backwards compatible: existing APIs work on the active farm implicitly
- No frontend breaking changes (selector is additive)
- Concurrent multi-farm simulation NOT supported (single active farm at a time)

https://claude.ai/code/session_01CQW7bJd7F1MrR8nqd2ZK9X