### PR TITLE
fix: prevent create farm modal overflow — scrollable body with max-he…

### DIFF
--- a/frontend/components/FarmSelector.tsx
+++ b/frontend/components/FarmSelector.tsx
@@ -211,9 +211,9 @@ const CreateFarmModal: React.FC<CreateModalProps> = ({ lang, onClose, onCreated 
   };
 
   return (
-    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[200] flex items-center justify-center p-4" onClick={onClose}>
-      <div className="bg-gray-800 border border-gray-600 rounded-xl shadow-2xl w-full max-w-md" onClick={e => e.stopPropagation()}>
-        <div className="px-5 py-4 border-b border-gray-700 flex items-center justify-between">
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[200] flex items-center justify-center p-4 overflow-y-auto" onClick={onClose}>
+      <div className="bg-gray-800 border border-gray-600 rounded-xl shadow-2xl w-full max-w-md my-auto max-h-[90vh] flex flex-col" onClick={e => e.stopPropagation()}>
+        <div className="px-5 py-4 border-b border-gray-700 flex items-center justify-between flex-shrink-0">
           <h2 className="text-lg font-bold text-white">{ui('Create Wind Farm', '建立新風場')}</h2>
           <button onClick={onClose} className="text-gray-400 hover:text-white transition-colors">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-5 h-5">
@@ -222,7 +222,7 @@ const CreateFarmModal: React.FC<CreateModalProps> = ({ lang, onClose, onCreated 
           </button>
         </div>
 
-        <div className="px-5 py-4 space-y-4">
+        <div className="px-5 py-4 space-y-4 overflow-y-auto flex-1">
           {/* Farm Name */}
           <div>
             <label className="block text-sm text-gray-300 mb-1">{ui('Farm Name', '風場名稱')} *</label>
@@ -300,7 +300,7 @@ const CreateFarmModal: React.FC<CreateModalProps> = ({ lang, onClose, onCreated 
           )}
         </div>
 
-        <div className="px-5 py-3 border-t border-gray-700 flex justify-end space-x-3">
+        <div className="px-5 py-3 border-t border-gray-700 flex justify-end space-x-3 flex-shrink-0">
           <button
             onClick={onClose}
             className="px-4 py-2 text-sm text-gray-300 hover:text-white transition-colors"


### PR DESCRIPTION
…ight

Modal was taller than viewport on small screens, hiding the farm name input at the top. Adds max-h-[90vh] with flex layout so the body scrolls internally while header and footer remain fixed.

https://claude.ai/code/session_01CQW7bJd7F1MrR8nqd2ZK9X