### PR TITLE
feat: add wind veer model with Ekman spiral blade direction offset (#79)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Still pending or incomplete:
 - full protection relay coordination (LVRT/OVRT) — see #67
 - coolant level / leak detection — done: level tracking + pump cavitation + fault coupling — see #75
 - gear tooth contact modeling — see #76
-- wind veer (directional shear with height) — see #79
+- wind veer (directional shear with height) — done: Ekman spiral model + blade lateral force coupling — see #79
 - SQLite vs time-series DB architecture decision — see #24
 - dependency security vulnerabilities (cryptography, pyjwt, etc.) — see #48
 - no automated test suite (pytest) — see #52

--- a/docs/daily_report.md
+++ b/docs/daily_report.md
@@ -4,53 +4,58 @@
 
 ## 昨日 Commit 摘要
 
-本次日報工作提交（分支 `claude/gifted-noether-PFU4Z`）：
-- [9815f9d] feat: add gearbox oil temperature and viscosity effects model (#73)
+本次日報工作提交（分支 `claude/gifted-noether-T5rZz`）：
+- [1266ec3] feat: add wind veer model with Ekman spiral blade direction offset (#79)
 
-過去 24 小時 main 分支合併：
-- [4982827] Merge pull request #70（塔架陰影效應）
-- [e35b21a] Merge pull request #68（峰值因子/峭度異常警報）
-- [f54dbf8] Merge pull request #66（齒輪嚙合邊帶分析模型）
-- [0e0e409] Merge pull request #65（BPFO/BPFI 軸承缺陷頻率模型）
-- [fbcd68a] Merge pull request #64（塔架 SDOF 動態響應）
-- [029b929] Merge pull request #63（Cp 氣動模型 + docstrings）
+過去 24 小時主要合併/提交：
+- [2b52e7d] Merge PR #85 — 建立風場對話框簡化
+- [cf57db8] Merge PR #84 — 建立風場彈窗佈局重寫
+- [9027346] Merge PR #83 — 建立風場彈窗溢出修復
+- [ee73469] Merge PR #82 — 新增建立風場對話框
+- [cb61c01] Merge PR #81 — 多風場管理功能（獨立 DB）
+- [612058f] Merge PR #77 — 齒輪箱油溫模型合併
+- [36b4fe1] Merge PR #80 — 文件更新
+- [1f3d747] feat: 冷卻液液位追蹤與洩漏偵測 (#75)
+- [4931b08] Merge PR #78 — 文件更新
+- [a7f000b] feat: 葉片質量不平衡離心力耦合 (#72)
+- [9815f9d] feat: 齒輪箱油溫與黏度效應 (#73)
+- [dbb6e16] feat: 風切剖面模型 (#71)
 
 ## Issue 狀態
 
 | 動作 | Issue # | 標題 | 說明 |
 |------|---------|------|------|
-| 關閉 | #73 | 齒輪箱油溫與黏度效應模型 | 已實作：Walther 型黏度比 + 冷啟動損耗衰減 + WDRV_GbxOilTmp 標籤 |
-| 新建 | #75 | 冷卻液液位與洩漏偵測模型 | physics_model_status §2.4 "Still missing"，啟用冷卻系統故障診斷 |
-| 新建 | #76 | 齒輪齒面接觸模型 | physics_model_status §2.2 "Still missing"，改善齒輪箱頻譜特徵 |
-| 保持 | #72 | 葉片質量不平衡與轉子動態不平衡 | 改善 1P 振動物理因果關係 |
-| 保持 | #71 | 風切剖面模型 | 高度相關風速分布與葉片不對稱載荷 |
-| 保持 | #67 | 完整保護繼電器協調 LVRT/OVRT | 電氣模型尚未加入保護曲線比對邏輯 |
+| 關閉 | #79 | 風向隨高度偏轉模型（Wind Veer） | 已實作：Ekman 螺旋 + 葉片側向力耦合 |
+| 關閉 | #75 | 冷卻液液位與洩漏偵測模型 | 已實作：液位追蹤 + 泵浦空蝕 + 故障耦合 |
+| 關閉 | #72 | 葉片質量不平衡與轉子動態不平衡 | 已實作：離心力 ω² 耦合 + 1P 振動 |
+| 關閉 | #71 | 風切剖面模型 | 已實作：power-law V(h) + 方位角葉片載荷 |
+| 新建 | #86 | 進階尾流模型（Bastankhah-Porté-Agel） | physics_model_status §2.6 "Still missing" |
+| 保持 | #76 | 齒輪齒面接觸模型 | 嚙合剛度與載荷分布 |
+| 保持 | #67 | 完整保護繼電器協調 LVRT/OVRT | 電壓-時間保護曲線 |
 | 保持 | #58 | 頻譜振動警報閾值與邊帶分析 | 頻帶警報曲線待做 |
-| 保持 | #57 | 疲勞警報閾值與 RUL 估算 | 後端完成，剩前端 RUL 視覺化 |
+| 保持 | #57 | 疲勞警報閾值與 RUL 估算 | 後端完成，前端 RUL 視覺化待做 |
 | 保持 | #52 | 缺少自動化測試套件 | 仍無 pytest |
-| 保持 | #51 | 警報處理透過 RAG 機制 | 用戶功能需求，待規劃 |
-| 保持 | #50 | 外部擷取資料 API | 用戶功能需求，待規劃 |
-| 保持 | #48 | pip-audit 17 個安全漏洞 | 漏洞數量不變，尚未升級 |
-| 保持 | #44 | Ruff lint 179 個錯誤 | 維持 115 個，核心模組 0 錯誤 |
-| 保持 | #26 | 部署強化 | Docker Compose 已完成，JWT/RBAC 待做 |
+| 保持 | #51 | 警報處理透過 RAG 機制 | 用戶功能需求 |
+| 保持 | #50 | 外部擷取資料 API | 用戶功能需求 |
+| 保持 | #48 | pip-audit 17 個安全漏洞 | 未升級 |
+| 保持 | #44 | Ruff lint 115 個錯誤 | 核心模組 0 錯誤 |
+| 保持 | #26 | 部署強化 | Docker 已完成，JWT/RBAC 待做 |
 | 保持 | #24 | 歷史資料儲存架構 | 架構決策待定 |
 
 ## Open Issues 總覽
 
 | # | 標題 | Labels | 建立日期 | 備註 |
 |---|------|--------|----------|------|
-| #76 | 齒輪齒面接觸模型 | enhancement, physics, auto-detected | 2026-04-17 | 新建 |
-| #75 | 冷卻液液位與洩漏偵測模型 | enhancement, physics, auto-detected | 2026-04-17 | 新建 |
-| #72 | 葉片質量不平衡與轉子動態不平衡 | enhancement, physics, auto-detected | 2026-04-17 | 改善 1P 振動因果 |
-| #71 | 風切剖面模型 | enhancement, physics, auto-detected | 2026-04-17 | 高度相關風速 |
-| #67 | 完整保護繼電器協調 LVRT/OVRT | enhancement, physics, auto-detected | 2026-04-16 | 電壓-時間保護曲線 |
+| #86 | 進階尾流模型（Bastankhah-Porté-Agel） | enhancement, physics, auto-detected | 2026-04-17 | 新建 |
+| #76 | 齒輪齒面接觸模型 | enhancement, physics, auto-detected | 2026-04-17 | 嚙合剛度 |
+| #67 | 完整保護繼電器協調 LVRT/OVRT | enhancement, physics, auto-detected | 2026-04-16 | 電壓-時間曲線 |
 | #58 | 頻譜振動警報閾值與邊帶分析 | enhancement, physics, auto-detected | 2026-04-15 | 頻帶警報曲線待做 |
-| #57 | 疲勞警報閾值與 RUL 估算 | enhancement, physics, auto-detected | 2026-04-15 | 前端 RUL 視覺化待做 |
+| #57 | 疲勞警報閾值與 RUL 估算 | enhancement, physics, auto-detected | 2026-04-15 | 前端 RUL 待做 |
 | #52 | 缺少自動化測試套件 | auto-detected, code-quality | 2026-04-14 | 無進展 |
 | #51 | 警報處理透過 RAG 機制 | — | 2026-04-14 | 用戶功能需求 |
 | #50 | 外部擷取資料 API | — | 2026-04-14 | 用戶功能需求 |
 | #48 | pip-audit 17 個安全漏洞 | security, auto-detected | 2026-04-13 | 未升級 |
-| #44 | Ruff lint 179 個錯誤 | code-quality, auto-detected | 2026-04-13 | 降至 115 個 |
+| #44 | Ruff lint 115 個錯誤 | code-quality, auto-detected | 2026-04-13 | 核心模組 0 錯誤 |
 | #26 | 部署強化 | enhancement, deployment | 2026-04-05 | Docker 已完成 |
 | #24 | 歷史資料儲存架構 | enhancement, platform | 2026-04-05 | 架構決策待定 |
 
@@ -58,12 +63,12 @@
 
 | 模組 | 最後修改 | TODO 數 | 測試 | 備註 |
 |------|----------|---------|------|------|
-| `server/` | 2026-04-16 | 0 | 無測試套件 | 無變更 |
-| `server/routers/` | 2026-04-16 | 0 | 無測試套件 | 無變更 |
-| `simulator/` | 2026-04-16 | 0 | 無測試套件 | 無變更 |
-| `simulator/physics/` | 2026-04-17 | 0 | 無測試套件 | 新增齒輪箱油溫/黏度 (#73) |
-| `frontend/` | 2026-04-15 | 0 | 無測試套件 | RUL 視覺化待實作 |
-| 根目錄原型 | 2026-04-12 | 0 | — | 早期原型檔案（dashboard.py 等） |
+| `server/` | 2026-04-17 | 0 | 無測試套件 | 新增 farm_registry.py、routers/farms.py |
+| `server/routers/` | 2026-04-17 | 0 | 無測試套件 | 新增 farms.py |
+| `simulator/` | 2026-04-17 | 0 | 無測試套件 | 無變更 |
+| `simulator/physics/` | 2026-04-17 | 0 | 無測試套件 | wind veer (#79) |
+| `frontend/` | 2026-04-17 | 0 | 無測試套件 | FarmSelector 元件新增 |
+| 根目錄原型 | 2026-04-12 | 0 | — | 早期原型檔案 |
 
 ## API Endpoints
 
@@ -122,46 +127,51 @@
 | GET | /api/export/history | 正常 | ✅ |
 | GET | /api/export/events | 正常 | ✅ |
 | WS | /ws/realtime | 正常 | ✅ |
+| GET | /api/farms | 正常 | ❌ 新增，未同步至 README |
+| POST | /api/farms | 正常 | ❌ 新增，未同步至 README |
+| GET | /api/farms/{id} | 正常 | ❌ 新增，未同步至 README |
+| POST | /api/farms/{id}/activate | 正常 | ❌ 新增，未同步至 README |
 
-共 54 個路由（53 HTTP + 1 WebSocket），全部與文件同步。
+共 58 個路由（57 HTTP + 1 WebSocket），54 個與文件同步，4 個新增路由待同步。
 
 ## 程式碼品質
 
 - Lint 錯誤：115（核心模組 server/ + simulator/ 維持 0 錯誤，剩餘皆在 opc_bachmann/ 和根目錄原型檔案）
-- 無 docstring 的公開函數：6 個（與上次相同）
-  - 根目錄原型：dashboard.py `update_charts()`、wind_model.py `get_status()`/`get_wind_direction()`/`get_ambient_temp()`
-  - 內部輔助：storage.py `to_float()` x2（巢狀函數，非模組級公開）
+- 無 docstring 的公開函數：14 個（+8 從新增的 farm_registry.py 和 data_broker.py）
+  - 根目錄原型：dashboard.py `update_charts()`、wind_model.py 3 個
+  - server/storage.py：`to_float()` x2（巢狀函數）
+  - server/farm_registry.py：`to_dict()`, `from_row()`, `get_farm()`, `list_farms()`, `get_active_farm_id()`, `set_active_farm()`, `get_farm_dir()` — 新增模組
+  - server/data_broker.py：`active_farm_id()` — 新增屬性
 - Broken imports：0（核心模組全部通過）
 - 語法錯誤：0
 - 測試套件：未建立（無 pytest）— 追蹤 issue #52
 - 安全漏洞：17 個（5 個套件），詳見 #48
 - TODO/FIXME/HACK：0 個（核心模組）
-- SCADA 標籤：91 個（+1 WDRV_GbxOilTmp）
+- SCADA 標籤：91 個（無變更）
 
 ## 今日新增功能
 
-### 齒輪箱油溫與黏度效應模型（#73）
-- **物理原理**：齒輪箱潤滑油黏度隨溫度變化，影響齒輪嚙合效率。低溫時黏度高、摩擦損耗大；高溫時油膜可能不足。冷啟動初期 ~10 分鐘效率較低。
+### 風向隨高度偏轉模型（#79）
+- **物理原理**：受科氏力和地表摩擦影響，風向隨高度偏轉（Ekman 螺旋效應）。離岸典型偏轉率 0.05–0.15 °/m。
 - **實作方式**：
-  1. `drivetrain_model.py`：新增油溫狀態變數，一階熱模型追蹤（齒輪損耗 + 軸承摩擦為熱源）
-  2. Walther 型黏度比：`visc_ratio = exp(-0.03 × (T_oil - 60°C))`
-  3. 冷啟動損耗因子：`1 + 0.5 × exp(-t_running / 600)`，前 10 分鐘額外損耗
-  4. 黏度損耗 80% 回饋至齒輪箱軸承熱量，形成溫度-效率閉迴路
-  5. 直驅風機跳過齒輪箱邏輯，油溫追蹤環境溫度
-  6. `scada_registry.py`：新增 `WDRV_GbxOilTmp` 標籤（°C，範圍 -30~120）
-- **驗證結果**：
-  - 冷啟動（5°C 環境）：初始損耗較穩態高 ~15%，10 分鐘衰減
-  - 暖環境（30°C）：穩態油溫 ~28°C，損耗較低
-  - 直驅風機：油溫 = 環境溫度 ✓
+  1. `wind_field.py`：新增 `blade_veer_offset_deg()` 靜態方法
+  2. `turbine_physics.py`：新增 `wind_veer_rate` 個體差異參數（0.07–0.13 °/m），計算等效偏航誤差導致的功率損失
+  3. `fatigue_model.py`：新增 veer 對塔架側向彎矩的淨側向力，以及葉片揮舞彎矩的側向力分量
+  4. `docs/physics_model_status.md`：更新 §2.6 和 §5
+- **物理效應**：
+  - 葉片尖端偏轉差異：±R × veer_rate（R=35m, veer=0.1°/m → ±3.5°）
+  - 塔架側向彎矩增加（veer 產生的淨側向推力）
+  - 葉片揮舞 1P 不對稱增大（側向力隨方位角變化）
+  - 功率因等效偏航誤差略微降低（cos² 效應）
 - **影響範圍**：
-  - 齒輪箱風機冬季冷啟動損耗更真實
-  - `gearbox_overheat` 故障的效率影響有溫度因果
-  - 齒輪箱軸承熱量增加黏度損耗成分
+  - 疲勞 DEL 增加（特別是塔架側向和葉片揮舞）
+  - 與風切剖面（#71）效應疊加，使 1P 載荷更真實
+  - 離岸風場模擬更貼近實際環境條件
 
 ## 建議行動
 
-1. **合併齒輪箱油溫模型**：已推送至 `claude/gifted-noether-PFU4Z`，可建立 PR 合併
-2. **實作 #71 風切剖面模型**：高度相關風速分布影響葉片載荷不對稱，基礎設施已就緒（轉子方位角 #69）
-3. **實作 #72 葉片質量不平衡**：改善 1P 振動從經驗公式轉為物理推導，使用已有的方位角追蹤
-4. **建立測試套件**（#52）：核心物理模型和 API endpoint 仍無自動化測試
-5. **升級有漏洞的套件**（#48）：優先處理 `cryptography`（7 個 CVE）
+1. **同步 README.md API 列表**：新增的 farms API（4 個路由）尚未列於 README
+2. **補充 farm_registry.py docstrings**：新增模組有 7 個公開函數缺少 docstring
+3. **實作 #86 進階尾流模型**：Bastankhah-Porté-Agel 高斯尾流，改善風場級功率預估
+4. **實作 #76 齒輪齒面接觸模型**：為 GMF 振動提供物理因果關係
+5. **建立測試套件**（#52）：核心物理模型和 API endpoint 仍無自動化測試

--- a/docs/physics_model_status.md
+++ b/docs/physics_model_status.md
@@ -335,9 +335,11 @@ Implemented:
 Newly implemented:
 - wind shear profile: power-law vertical wind profile with configurable exponent (default α=0.2, per-turbine variation ±0.04-0.06), azimuth-dependent blade loading in fatigue model (see #71)
 
+Newly implemented:
+- wind veer (directional shear with height): linear Ekman spiral model, per-turbine veer rate (0.07–0.13 °/m), azimuth-dependent blade direction offset, lateral force coupling to tower SS and blade flapwise moments (see #79)
+
 Still missing:
 - localized turbulence pockets
-- wind veer (directional shear with height)
 - more sophisticated wake model (e.g. Frandsen, Bastankhah)
 
 ## 3. Not Yet Modeled
@@ -492,10 +494,11 @@ Implemented:
 - full protection relay coordination (LVRT/OVRT)
 - aeroelastic coupling (BEM; tower first-mode SDOF is implemented)
 - frontend RUL visualization — see #57 (alarm event integration completed)
-- full blade element loading distribution (tower shadow 3P + wind shear 1P implemented, full BEM missing)
+- full blade element loading distribution (tower shadow 3P + wind shear 1P + wind veer implemented, full BEM missing)
 - ~~blade mass imbalance and rotor dynamic imbalance~~ → done (#72, centrifugal force ω² coupling)
 - ~~gearbox oil temperature and viscosity effects~~ → done (#73, Walther equation)
 - ~~coolant level / leak detection~~ → done (#75, level tracking + pump cavitation + fault coupling)
+- ~~wind veer (directional shear with height)~~ → done (#79, Ekman spiral + blade lateral force coupling)
 
 ### Recommended Immediate Direction
 1. ~~blade mass imbalance with speed² coupling for 1P vibration~~ → done (#72)
@@ -508,4 +511,5 @@ Implemented:
 7. ~~tower dynamic natural frequency response~~ → done (#62, SDOF first-mode filter)
 8. ~~tower shadow effect~~ → done (#69, rotor azimuth tracking + 3P Gaussian shadow model)
 9. ~~wind shear profile~~ → done (#71, power-law V(h) with azimuth-dependent blade loading)
-10. deployment hardening (JWT auth, RBAC, Docker Compose)
+10. ~~wind veer (directional shear with height)~~ → done (#79, Ekman spiral model)
+11. deployment hardening (JWT auth, RBAC, Docker Compose)

--- a/simulator/physics/fatigue_model.py
+++ b/simulator/physics/fatigue_model.py
@@ -213,7 +213,8 @@ class FatigueModel:
              is_emergency_stop: bool,
              rotor_azimuth_rad: float = 0.0,
              wind_shear_exponent: float = 0.2,
-             imbalance_force_kn: float = 0.0) -> Dict[str, float]:
+             imbalance_force_kn: float = 0.0,
+             wind_veer_rate: float = 0.0) -> Dict[str, float]:
         """Advance fatigue model by one timestep.
 
         Args:
@@ -243,6 +244,7 @@ class FatigueModel:
             turbulence_intensity, is_producing, is_starting,
             is_emergency_stop, dt, rotor_azimuth_rad,
             wind_shear_exponent, imbalance_force_kn,
+            wind_veer_rate,
         )
 
         self.load_tower_fa = loads["tower_fa"]
@@ -383,7 +385,8 @@ class FatigueModel:
                        dt: float,
                        rotor_azimuth_rad: float = 0.0,
                        wind_shear_exponent: float = 0.2,
-                       imbalance_force_kn: float = 0.0) -> Dict[str, float]:
+                       imbalance_force_kn: float = 0.0,
+                       wind_veer_rate: float = 0.0) -> Dict[str, float]:
         """Compute instantaneous structural loads (kNm)."""
         rho = 1.225  # air density
         R = self._rotor_diameter / 2
@@ -421,7 +424,14 @@ class FatigueModel:
         lateral_thrust = thrust_kn * abs(math.sin(yaw_rad)) if thrust_kn > 0 else 0.0
         imb_ss = imbalance_force_kn * H * 0.3 if rotor_speed_rpm > 1 else 0.0
 
-        tower_ss = (lateral_thrust * H * 0.3 + imb_ss +
+        # Wind veer: height-dependent direction creates net lateral force on rotor (#79)
+        veer_ss = 0.0
+        if wind_veer_rate > 0 and thrust_kn > 0 and is_producing:
+            veer_tip_deg = wind_veer_rate * R
+            veer_lateral_kn = thrust_kn * abs(math.sin(math.radians(veer_tip_deg))) * 0.5
+            veer_ss = veer_lateral_kn * H * 0.2
+
+        tower_ss = (lateral_thrust * H * 0.3 + imb_ss + veer_ss +
                     abs(self._rng.normal(0, turb_dynamic * 0.08)))
 
         # ── Blade flapwise bending moment ──
@@ -451,6 +461,11 @@ class FatigueModel:
                 ts_delta = 2.0 * math.pi - ts_delta
             ts_blade = 1.0 - 0.12 * math.exp(-0.5 * (ts_delta / 0.15) ** 2)
             blade_flap *= ts_blade
+
+            # Wind veer: direction offset at blade height creates lateral force (#79)
+            if wind_veer_rate > 0:
+                veer_offset_rad = math.radians(wind_veer_rate * R * 0.7 * math.cos(blade_az))
+                blade_flap += blade_thrust * abs(math.sin(veer_offset_rad)) * R * 0.667 * 0.3
 
             # Blade mass imbalance: centrifugal force modulates flapwise moment (#72)
             blade_flap += imbalance_force_kn * R * 0.15

--- a/simulator/physics/turbine_physics.py
+++ b/simulator/physics/turbine_physics.py
@@ -184,6 +184,7 @@ class TurbinePhysicsModel:
             "tower_shadow_amp": 0.12 + self._rng.uniform(-0.03, 0.03),
             "wind_shear_exp": 0.2 + self._rng.uniform(-0.04, 0.06),
             "blade_mass_offsets": _blade_mass_offsets,
+            "wind_veer_rate": 0.10 + self._rng.uniform(-0.03, 0.03),
         }
 
         self.power_curve = PowerCurveModel(
@@ -380,6 +381,17 @@ class TurbinePhysicsModel:
         shear_torque_factor /= 3.0  # average across 3 blades, force ~ V²
         aero_out.aero_torque_knm *= shear_torque_factor
         aero_out.thrust_kn *= shear_torque_factor
+
+        # Wind veer: direction offset with height → equivalent yaw error per blade (#79)
+        veer_rate = self._individuality.get("wind_veer_rate", 0.10)
+        if is_producing and omega_rad > 0.1 and veer_rate > 0:
+            veer_power_loss = 0.0
+            for i in range(3):
+                blade_az = (self._rotor_azimuth + i * math.tau / 3.0) % math.tau
+                veer_offset_rad = math.radians(veer_rate * R * math.cos(blade_az))
+                veer_power_loss += (1.0 - math.cos(veer_offset_rad) ** 2) / 3.0
+            aero_out.aero_torque_knm *= (1.0 - veer_power_loss)
+            aero_out.power_kw *= (1.0 - veer_power_loss)
 
         # Blade mass imbalance: centrifugal force F = Δm × r_cg × ω² (#72)
         blade_mass_offsets = self._individuality["blade_mass_offsets"]
@@ -623,6 +635,7 @@ class TurbinePhysicsModel:
             rotor_azimuth_rad=self._rotor_azimuth,
             wind_shear_exponent=self._individuality.get("wind_shear_exp", 0.2),
             imbalance_force_kn=self._imbalance_force_kn,
+            wind_veer_rate=self._individuality.get("wind_veer_rate", 0.10),
         )
 
         # IGCT water pressure now driven by cooling system pump (#29)

--- a/simulator/physics/wind_field.py
+++ b/simulator/physics/wind_field.py
@@ -444,3 +444,16 @@ class PerTurbineWind:
         h_blade = max(10.0, h_blade)
         return (h_blade / hub_height) ** shear_exp
 
+    @staticmethod
+    def blade_veer_offset_deg(rotor_radius: float,
+                              blade_azimuth_rad: float,
+                              veer_rate_deg_per_m: float) -> float:
+        """Wind direction offset (degrees) at blade position due to wind veer.
+
+        Ekman spiral: θ(h) = θ_hub + veer_rate × (h - h_hub).
+        Blade height offset = R × cos(azimuth), where azimuth=0 is top-dead-center.
+        Offshore typical veer_rate: 0.05–0.15 °/m.
+        """
+        h_offset = rotor_radius * math.cos(blade_azimuth_rad)
+        return veer_rate_deg_per_m * h_offset
+


### PR DESCRIPTION
## Summary
Implements wind veer (directional shear with height) modeling using an Ekman spiral approach. Wind direction now varies with blade height, creating azimuth-dependent lateral forces that couple into tower side-side and blade flapwise bending moments.

## Key Changes

### Wind Field Model (`simulator/physics/wind_field.py`)
- Added `blade_veer_offset_deg()` static method to compute directional offset at blade position
- Implements linear Ekman spiral: θ(h) = θ_hub + veer_rate × (h - h_hub)
- Blade height offset calculated as R × cos(azimuth)

### Turbine Physics (`simulator/physics/turbine_physics.py`)
- Added per-turbine `wind_veer_rate` individuality parameter (0.07–0.13 °/m, default 0.10 ±0.03)
- Computes equivalent yaw error for each blade based on azimuth-dependent veer offset
- Applies power loss factor: `1 - cos²(veer_offset)` per blade, averaged across 3-blade rotor
- Reduces aerodynamic torque and power output when veer is present

### Fatigue Model (`simulator/physics/fatigue_model.py`)
- Added `wind_veer_rate` parameter to `step()` and `_compute_loads()` methods
- **Tower side-side moment**: veer creates net lateral thrust component (0.5 × thrust × sin(veer_tip_angle) × H × 0.2)
- **Blade flapwise moment**: azimuth-dependent lateral force offset (sin(veer_offset_rad) × thrust × R × 0.667 × 0.3)
- Veer effects scale with rotor radius and blade azimuth position

### Documentation (`docs/physics_model_status.md`, `CLAUDE.md`)
- Moved wind veer from "Still missing" to "Newly implemented" in physics model status
- Updated recommended direction list to mark #79 as complete
- Noted interaction with wind shear profile (#71) for realistic 1P loading

## Physical Effects
- **Blade tip deflection difference**: ±R × veer_rate (e.g., 35m rotor, 0.1°/m veer → ±3.5°)
- **Tower lateral loading**: Net side-side moment from veer-induced thrust component
- **Blade flapwise asymmetry**: 1P moment increases due to azimuth-dependent direction offset
- **Power reduction**: Equivalent yaw error effect (cos² loss factor)
- **Fatigue impact**: DEL increases especially for tower side-side and blade flapwise, particularly in offshore conditions

## Notes
- Typical offshore veer rate: 0.05–0.15 °/m (Ekman spiral in boundary layer)
- Veer effects compound with wind shear profile (#71) for more realistic load distribution
- Per-turbine variation captures site-specific atmospheric conditions

https://claude.ai/code/session_011NsBNGqRZrhw8675WUM6f5