### PR TITLE
feat: upgrade wake model to Bastankhah-Porté-Agel Gaussian (#93)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Current Position
 
-A working wind farm simulation platform with 94 SCADA tags, comprehensive physics models, and full API access for external data consumers.
+A working wind farm simulation platform with 95 SCADA tags, comprehensive physics models, and full API access for external data consumers.
 
 Platform includes:
 - backend REST + WebSocket APIs (40+ endpoints)
@@ -30,6 +30,7 @@ Primary focus (next improvements):
 - gear tooth contact — fixed: contact-ratio mesh stiffness ripple + tooth wear index + GMF HSS-torsion excitation — see #76
 - ambient humidity air-cooling — fixed: moist-air density factor + dew-point condensation penalty on nacelle/cabinet fans — see #89
 - localized turbulence pockets — fixed: spatial Gaussian pockets boost per-turbine TI, observable via `WMET_LocalTi` — see #91
+- wake model upgrade — fixed: Bastankhah-Porté-Agel Gaussian wake (TI-dependent expansion, Ct-coupled deficit, sum-of-squares superposition), observable via `WMET_WakeDef` — see #93
 
 Secondary focus:
 - deployment hardening (JWT, Docker) — only when ready to share externally
@@ -69,6 +70,7 @@ Still pending or incomplete:
 - wind veer (directional shear with height) — done: Ekman spiral model + blade lateral force coupling — see #79
 - ambient humidity effect on air cooling — done: moist-air density + dew-point condensation penalty (#89)
 - localized turbulence pockets — done: Gaussian spatial pockets with per-turbine TI boost + `WMET_LocalTi` tag (#91)
+- wake model (Bastankhah-Porté-Agel Gaussian) — done: TI-dependent expansion, Ct-coupled max deficit, sum-of-squares superposition + `WMET_WakeDef` tag (#93)
 - SQLite vs time-series DB architecture decision — see #24
 - dependency security vulnerabilities (cryptography, pyjwt, etc.) — see #48
 - no automated test suite (pytest) — see #52

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Wind farm monitoring and digital twin platform with:
 - physics-based wind turbine simulation
-- 94 SCADA tags aligned to Bachmann Z72 definitions
+- 95 SCADA tags aligned to Bachmann Z72 definitions
 - fault injection and degradation scenarios
 - wind and grid condition control
 - Modbus TCP simulation
@@ -234,6 +234,7 @@ Historical storage currently grows continuously and does not yet have a cleanup 
 - coolant level / leak detection implemented (level tracking, pump cavitation, fault coupling) — see #75
 - ambient humidity effect on air cooling implemented (moist-air density + dew-point condensation penalty) — see #89
 - localized turbulence pockets implemented (Gaussian spatial TI boost pockets, per-turbine TI multiplier, `WMET_LocalTi` tag) — see #91
+- wake model upgraded to Bastankhah-Porté-Agel Gaussian (TI-dependent expansion, Ct-coupled deficit, sum-of-squares superposition, `WMET_WakeDef` tag) — see #93
 - full protection relay coordination not yet implemented
 - frontend RUL visualization pending (fatigue alarm thresholds, RUL estimation, and alarm event integration implemented — see #57)
 - dependency security vulnerabilities pending upgrade (see #48)

--- a/TODO.md
+++ b/TODO.md
@@ -49,6 +49,8 @@
 - [x] 93 SCADA tags total (was 92): +1 outside relative humidity tag (`WMET_HumOutside`)
 - [x] Localized turbulence pockets (Gaussian spatial TI boost per pocket, AR(1) turbulence × per-turbine TI multiplier) — see #91
 - [x] 94 SCADA tags total (was 93): +1 local TI multiplier tag (`WMET_LocalTi`)
+- [x] Bastankhah-Porté-Agel Gaussian wake model (TI-dependent expansion k* = 0.38·TI+0.004, Ct-coupled max deficit, Gaussian radial profile, sum-of-squares multi-wake superposition) — see #93
+- [x] 95 SCADA tags total (was 94): +1 wake velocity deficit tag (`WMET_WakeDef`)
 
 ### Backend
 - [x] FastAPI REST APIs
@@ -179,6 +181,7 @@ These parts are implemented, but still first-generation models:
 - [x] Gearbox oil temperature/viscosity: Walther equation, cold-start efficiency loss, overheat degradation — see #73
 - [x] Ambient humidity effect on air cooling: moist-air density factor + dew-point condensation penalty, seasonal/diurnal humidity profile — see #89
 - [x] Localized turbulence pockets: Gaussian spatial pockets with stochastic spawn (~1 per 10–15 min), per-turbine TI multiplier boost, exposed via `WMET_LocalTi` — see #91
+- [x] Wake model upgrade: Bastankhah-Porté-Agel Gaussian wake (replaces simplified Jensen top-hat); TI-dependent expansion, Ct-coupled deficit, sum-of-squares multi-wake superposition, exposed via `WMET_WakeDef` — see #93
 
 ### Deployment (low priority — lab-only use currently)
 - [ ] JWT authentication

--- a/docs/daily_report.md
+++ b/docs/daily_report.md
@@ -2,12 +2,14 @@
 
 > 最後更新：2026-04-20
 
-## 昨日 Commit 摘要
+## 今日 Commit 摘要
 
-本次日報工作提交（分支 `claude/keen-hopper-sQJ2G`）：
-- feat: add localized turbulence pockets (Gaussian spatial TI boost) — 對應 #91
+本次日報工作提交（分支 `claude/keen-hopper-pDlDb`）：
+- feat: upgrade wake model to Bastankhah-Porté-Agel Gaussian (#93)
 
-過去 24 小時主要合併/提交：
+近 24 小時合併/提交摘要：
+- [45c2f20] Merge PR #92 — 局部亂流袋（#91）
+- [fab8bf9] feat: add localized turbulence pockets with Gaussian spatial TI boost (#91)
 - [b788861] Merge PR #90 — 環境濕度影響空氣冷卻（#89）
 - [a102cfc] feat: add ambient humidity air-cooling model with dew-point penalty (#89)
 
@@ -15,8 +17,8 @@
 
 | 動作 | Issue # | 標題 | 說明 |
 |------|---------|------|------|
-| 建立 | #91 | 局部亂流袋（localized turbulence pockets） | TODO/physics_model_status 列為 Still missing 但無對應 issue；本日建立並同步實作 |
-| 關閉 | #91 | 局部亂流袋 | 已實作：Gaussian spatial pocket、stochastic spawn、per-turbine TI multiplier、`WMET_LocalTi` 標籤 |
+| 建立 | #93 | 尾流模型升級：Bastankhah-Porté-Agel 高斯尾流 | Jensen top-hat 模型過度簡化；本日建立並實作 |
+| 關閉 | #93 | 尾流模型升級 | 已實作 Bastankhah-Porté-Agel + Ct 耦合 + TI 依賴膨脹 + SoS 疊加 + `WMET_WakeDef` 標籤 |
 | 保持 | #67 | 完整保護繼電器協調 LVRT/OVRT | 電壓-時間保護曲線 |
 | 保持 | #58 | 頻譜振動警報閾值與邊帶分析 | 頻帶警報曲線待做 |
 | 保持 | #57 | 疲勞警報閾值與 RUL 估算 | 後端完成，前端 RUL 視覺化待做 |
@@ -28,7 +30,7 @@
 | 保持 | #26 | 部署強化 | Docker 已完成，JWT/RBAC 待做 |
 | 保持 | #24 | 歷史資料儲存架構 | 架構決策待定 |
 
-本日建立並關閉 1 個 issue（#91），符合「每次最多 3 個新 issue」規則。
+本日建立並關閉 1 個 issue（#93），符合「每次最多 3 個新 issue」規則。
 
 ## Open Issues 總覽
 
@@ -50,8 +52,8 @@
 | 模組 | 最後修改 | TODO 數 | 測試 | 備註 |
 |------|----------|---------|------|------|
 | `server/` | 2026-04-17 | 0 | 無測試套件 | 無變更 |
-| `simulator/` | 2026-04-20 | 0 | 無測試套件 | `engine.py` 傳入 `local_ti_multiplier` |
-| `simulator/physics/` | 2026-04-20 | 0 | 無測試套件 | `wind_field` 新增亂流袋；`turbine_physics`、`scada_registry` 接線 |
+| `simulator/` | 2026-04-20 | 0 | 無測試套件 | `engine.py` 傳入 `wake_deficit` |
+| `simulator/physics/` | 2026-04-20 | 0 | 無測試套件 | `wind_field.py` 升級為 Bastankhah 高斯尾流；`turbine_physics`、`scada_registry` 新增 `WMET_WakeDef` |
 | `wind_model.py`（根目錄） | 2026-04-19 | 0 | 無測試套件 | 無變更 |
 | `frontend/` | 2026-04-17 | 0 | 無測試套件 | 無變更 |
 | 根目錄原型 | 2026-04-12 | 0 | — | 早期原型檔案 |
@@ -72,55 +74,71 @@
 - 測試套件：未建立（無 pytest）— 追蹤 issue #52
 - 安全漏洞：17 個（5 個套件），詳見 #48
 - TODO/FIXME/HACK：0 個（核心模組）
-- SCADA 標籤：**94 個**（+1：`WMET_LocalTi`）
+- SCADA 標籤：**95 個**（+1：`WMET_WakeDef`）
 
 ## 今日新增功能
 
-### 局部亂流袋（localized turbulence pockets, #91）
+### Bastankhah-Porté-Agel 高斯尾流模型（#93）
 
 **物理原理**
 
-- 離岸風場邊界層中，除了全場尺度的亂流統計外，還會出現尺度較小（100–500 m）、持續時間較短（30–180 s）的局部 coherent 亂流結構
-- 主因：對流邊界層的熱通量不均勻、上游尾流破裂（wake breakdown）、海面應力局部變化
-- 袋**不改變平均風速**，而是**放大 TI（亂流強度）**，造成袋內 1–3 台相鄰風機的風速標準差、功率 CV、振動 broadband 短暫升高
+- 舊模型為簡化的 Jensen/Park top-hat：`deficit = 0.08 × alignment × (200/dist)^0.5`，硬性 clip 至 0.85
+  - 問題 1：尾流赤字與推力係數 Ct 無耦合，僅為經驗常數
+  - 問題 2：side-to-side 無 Gaussian 衰減，只是 cos(θ) > 0.3 的圓錐檢查
+  - 問題 3：下游距離以經驗根號衰減，非物理的線性膨脹
+  - 問題 4：多尾流用乘法疊加，不是標準 sum-of-squares
+- 新模型為 Bastankhah-Porté-Agel 2014 高斯尾流（風能界最通用的解析尾流模型之一）：
+  - 近尾流偏移：ε/D = 0.25 × √((1 + √(1 − Ct)) / (2√(1 − Ct)))
+  - 線性膨脹：σ(x)/D = k* × (x/D) + ε/D
+  - 最大赤字（中心軸）：C(x) = 1 − √(1 − Ct / (8·(σ/D)²))
+  - 徑向 Gaussian：ΔU(x,r)/U∞ = C(x) × exp(−0.5·(r/σ)²)
+- 尾流膨脹率（Niayifar & Porté-Agel 2016）：k* ≈ 0.38·TI + 0.004
+  - TI=0.06（離岸低亂流）→ k* ≈ 0.027（尾流恢復慢，深尾流持續遠）
+  - TI=0.20（高亂流）→ k* ≈ 0.080（尾流快速恢復）
+- 多尾流疊加改為 sum-of-squares：ΔU_total/U = √(Σ (ΔU_i/U)²)
 
 **實作方式**
 
 1. `simulator/physics/wind_field.py`：
-   - 新增 `TurbulencePocket` dataclass（中心座標、Gaussian 半徑 σ、TI 倍率、rise/hold/fall 壽命）
-   - `PerTurbineWind` 新增 `_pockets: List[TurbulencePocket]`、`_pocket_sim_time`、`_current_ti_multipliers`
-   - `_update_turbulence_pockets()`：stochastic spawn（機率 `dt × (0.0006 + 0.0004 × max(0, farm_wind − 6))`，約每 10–15 min 1 顆於 10 m/s），袋心位置隨機錨定任一風機附近 ±250 m，半徑 180–380 m，TI 倍率 1.4–2.0×
-   - 空間權重：`w_i = exp(-dist²/(2σ²))`（Gaussian）
-   - 時間包絡：cosine rise → flat hold → cosine fall
-   - 每台風機 `TI_eff_i = TI_base × (1 + Σ(boost_k × w_i,k × env_k(t)))`
-   - 餵給原有 `TurbulenceGenerator.step`，放大 AR(1) 白噪音的 σ
-2. `simulator/engine.py`：每步取得 `get_local_ti_multiplier(idx)` 並傳入 `turbine.step`
-3. `simulator/physics/turbine_physics.py`：`step()` 新增 `local_ti_multiplier` kwarg，輸出 `WMET_LocalTi`（%，相對基準 TI 的倍率 × 100）
-4. `simulator/physics/scada_registry.py`：新增 `WMET_LocalTi`（REAL32, %, 80–300）
+   - `PerTurbineWind.__init__` 新增 `rotor_diameter: float = 70.65` 參數與 `self._wake_deficits` 狀態陣列
+   - `_update_wake_factors(wind_direction, mean_wind, turbulence_intensity)` 重寫為 Bastankhah-Porté-Agel 公式
+   - Ct 啟發式：V<3 m/s 為 0；Region 2 (3 ≤ V < 11) 為 0.82 − 0.015·|V−8|；Region 3 為 0.82·(V_rated/V)²（限制 0.05-0.90）
+   - k* = max(0.02, 0.38·TI + 0.004)
+   - 下游距離 x_down ≤ 0.5·D 視為不受尾流影響（含側向與上游）
+   - 當判別式 1 − Ct/(8·(σ/D)²) ≤ 0（極近尾流）時 cap 在 C_max = 0.70
+   - 最終 `self._wake_factors = 1.0 − np.clip(total_deficit, 0, 0.70)`
+   - 新增公開方法 `get_wake_deficit(turbine_index)`
+2. `simulator/engine.py`：每步取得 `get_wake_deficit(idx)` 並傳入 `turbine.step`
+3. `simulator/physics/turbine_physics.py`：
+   - `step()` 新增 `wake_deficit: float = 0.0` kwarg
+   - `reset()` 與 `__init__` 新增 `_wake_deficit = 0.0`
+   - 輸出 `WMET_WakeDef`（%，wake velocity deficit）
+4. `simulator/physics/scada_registry.py`：新增 `WMET_WakeDef`（REAL32, %, 0–70）
 
 **物理效應（自測驗證）**
 
-| 條件 | 預期 WMET_LocalTi | 實測 |
-|------|-------------------|------|
-| 無袋（基準） | 100% | 100.0 ✓ |
-| 袋心 1.8×，袋半徑 250 m，距袋心 0 m | ~180% | 180.0 ✓ |
-| 袋心 1.8×，袋半徑 250 m，距袋心 500 m | ~110% | 110.8 ✓（高斯衰減） |
-| 袋心 1.8×，袋半徑 250 m，距袋心 1500 m | ~100% | 100.0 ✓（袋外） |
-| 鄰近兩台在同一袋內（相距 430 m） | 同步升高 | 兩台同時 118% ✓ |
+| 條件 | 預期 | 實測 |
+|------|------|------|
+| 3 台一列、500 m 間距、風速 10 m/s 270°、TI=0.08 | 上游 0%，下游深尾流 15–20% | T0=0% / T1=17.3% / T2=19.1% ✓ |
+| 風向 0°（側向吹、無尾流重疊） | 所有 0% | 全部 0.0% ✓ |
+| 16 m/s（Region 3，Ct≈0.39） | 赤字下降 | T1=12.4% / T2=13.8% ✓ |
+| TI=0.20（高亂流，k*≈0.080） | 尾流快速恢復 | T1=6.6% / T2=7.0% ✓ |
+| 2 m/s（cut-in 以下，Ct=0） | 全部 0% | 全部 0.0% ✓ |
 
 **影響範圍**
 
-- `WMET_LocalTi` 可於歷史圖表觀察局部亂流事件（典型持續 30–180 s）
-- 袋作用時段：振動 broadband/HF 頻帶短期升 20–30%，DEL 小幅升高（因亂流驅動的 σ 放大 → 塔基與葉根彎矩 variance 增加）
-- 相鄰風機之 `WMET_LocalTi` 具空間相關性，可作為故障診斷輔助訊號（排除單機故障誤報）
-- 平均風速（`WMET_WdSpd`）不變，僅風速標準差與振動變化，與真實邊界層現象一致
-- 為未來尾流破裂、對流邊界層模型鋪前置介面
+- `WMET_WakeDef` 可於歷史圖表觀察風向改變時的尾流關係切換（風向旋轉 → 尾流方向跟著旋轉 → 不同機組進入/離開尾流）
+- 尾流赤字上限從舊模型的 15%（clip 0.85）提升至 70%，更真實反映深尾流
+- 高 TI 時尾流快速恢復 → 符合大氣穩定度對尾流長度的影響（離岸低穩定度 vs 日間對流）
+- Region 3 尾流赤字下降 → 符合變槳後 Ct 下降的物理
+- 為未來前端尾流視覺化、Lillgrund / Horns Rev 風場基準驗證鋪前置介面
 
 ## 建議行動
 
-1. **整合測試 #91**：建議在 `examples/data_quality_analysis.py` 追加「局部亂流期間 vs 平穩期間」的振動/DEL 比對（可人工注入袋驗證）。
-2. **前端視覺化 #91**：Dashboard 可加上 `WMET_LocalTi` 迷你圖，輔助辨識目前有無袋影響。
-3. **實作 #58 頻譜警報曲線**：前端顯示各頻帶警報閾值（目前已有 ISO 10816 分區但未以曲線形式顯示）。
-4. **實作 #57 前端 RUL 視覺化**：後端已就緒，前端 Load/Fatigue 分頁補 RUL 顯示。
-5. **同步 `/api/farms` 4 個路由至 README.md**：仍未完成。
-6. **建立測試套件（#52）**：袋空間權重、時間包絡、生成機率計算均具數值預期，適合做為物理模型 pytest 第一批案例。
+1. **整合測試 #93**：建議在 `examples/data_quality_analysis.py` 追加「風向旋轉前後下游風機功率變化」以驗證尾流方向耦合。
+2. **前端視覺化 #93**：Dashboard 可新增尾流熱圖（以風場佈局 + `WMET_WakeDef` 顏色編碼呈現），對操作員直觀展示尾流效應。
+3. **Lillgrund / Horns Rev 基準驗證**：以業界公開基準資料（8D 間距 LES）比對模型輸出，校準 k* 與 Ct 啟發式。
+4. **實作 #58 頻譜警報曲線**：前端顯示各頻帶警報閾值。
+5. **實作 #57 前端 RUL 視覺化**：後端已就緒，前端 Load/Fatigue 分頁補 RUL 顯示。
+6. **同步 `/api/farms` 4 個路由至 README.md**：仍未完成。
+7. **建立測試套件（#52）**：Bastankhah 尾流模型的數值預期（Ct→ε/D、k*→σ(x)/D、C_max 判別式）非常適合做為物理模型 pytest 第一批案例。

--- a/docs/physics_model_status.md
+++ b/docs/physics_model_status.md
@@ -1,6 +1,6 @@
 # Physics Model Status
 
-Last updated: 2026-04-20
+Last updated: 2026-04-20 (wake model upgrade)
 
 This document tracks the current completion status of the wind turbine physics models.
 It is intended to be the single reference for:
@@ -347,8 +347,11 @@ Newly implemented:
 Newly implemented:
 - localized turbulence pockets (#91): Gaussian spatial pockets (R=180–380 m), stochastic spawn (~1 per 10–15 min at 10 m/s), TI multiplier 1.4–2.0× at pocket center with Gaussian falloff, rise/hold/fall envelope; applies per-turbine TI boost to `TurbulenceGenerator`; new SCADA tag `WMET_LocalTi` (local TI multiplier %)
 
+Newly implemented:
+- Bastankhah-Porté-Agel Gaussian wake model (#93): replaces the simplified Jensen top-hat. Implements ε/D near-wake offset, linear wake expansion σ(x)/D = k*·(x/D)+ε/D with TI-dependent k* (Niayifar & Porté-Agel 2016 k*≈0.38·TI+0.004), Ct-coupled max deficit C(x)=1−√(1−Ct/(8·(σ/D)²)), Gaussian radial profile, and sum-of-squares multi-wake superposition. Ct heuristically follows operating point (~0.82 in Region 2, drops with V² above rated). New SCADA tag `WMET_WakeDef` (wake velocity deficit %).
+
 Still missing:
-- more sophisticated wake model (e.g. Frandsen, Bastankhah)
+- more sophisticated wake model (e.g. curled-wake for skewed inflow, Frandsen with yaw-induced deflection)
 
 ## 3. Not Yet Modeled
 
@@ -495,7 +498,7 @@ Implemented:
 - spectral vibration bands with fault-specific signatures
 - vibration alarm thresholds with ISO 10816-inspired zones
 - fatigue / load modeling (tower + blade moments, DEL, Miner's damage, alarm thresholds, RUL, tower SDOF dynamics)
-- 94 SCADA tags (electrical + vibration + structural load + alarm/RUL + bearing diagnostics + gear mesh sidebands + crest/kurtosis alarms + gearbox oil temp + tooth wear + outside humidity + local TI multiplier)
+- 95 SCADA tags (electrical + vibration + structural load + alarm/RUL + bearing diagnostics + gear mesh sidebands + crest/kurtosis alarms + gearbox oil temp + tooth wear + outside humidity + local TI multiplier + Bastankhah wake deficit)
 
 ### Still Weak
 - spectral alarm threshold curves — see #58 (crest factor/kurtosis anomaly alarms now completed)
@@ -523,4 +526,5 @@ Implemented:
 10. ~~wind veer (directional shear with height)~~ → done (#79, Ekman spiral model)
 11. ~~gear tooth contact modeling~~ → done (#76, contact-ratio mesh stiffness + tooth wear)
 12. ~~localized turbulence pockets~~ → done (#91, Gaussian spatial TI boost pockets)
-13. deployment hardening (JWT auth, RBAC, Docker Compose)
+13. ~~Bastankhah-Porté-Agel Gaussian wake model~~ → done (#93, TI-dependent expansion + Ct-coupled deficit + sum-of-squares)
+14. deployment hardening (JWT auth, RBAC, Docker Compose)

--- a/simulator/engine.py
+++ b/simulator/engine.py
@@ -119,6 +119,7 @@ class WindFarmSimulator:
             local_wind = self._per_turbine_wind.get_local_wind(farm_wind, idx)
             local_direction = self._per_turbine_wind.get_local_direction(wind_direction, idx)
             local_ti_multiplier = self._per_turbine_wind.get_local_ti_multiplier(idx)
+            wake_deficit = self._per_turbine_wind.get_wake_deficit(idx)
 
             model.active_faults = [
                 {
@@ -143,6 +144,7 @@ class WindFarmSimulator:
                 grid_voltage_ref=grid_voltage,
                 ambient_humidity_pct=ambient_humidity,
                 local_ti_multiplier=local_ti_multiplier,
+                wake_deficit=wake_deficit,
             )
 
             output = self._scada_to_output(tid, sim_time, scada_output, local_wind, wind_direction)

--- a/simulator/physics/scada_registry.py
+++ b/simulator/physics/scada_registry.py
@@ -158,6 +158,10 @@ _TAGS: List[ScadaTag] = [
              "WMET", "REAL32", "%", "Local Turbulence Intensity Multiplier",
              "局部亂流強度倍率",
              80, 300),
+    ScadaTag("WMET_WakeDef", "WMET.Z72PLC__UI_Loc_WMET_Analogue_WakeDef",
+             "WMET", "REAL32", "%", "Wake Velocity Deficit",
+             "尾流風速赤字",
+             0, 70),
 
     # ══════════════════════════════════════════════════════════════════════
     # WNAC — Nacelle

--- a/simulator/physics/turbine_physics.py
+++ b/simulator/physics/turbine_physics.py
@@ -248,6 +248,7 @@ class TurbinePhysicsModel:
         self._rotor_azimuth = self._rng.uniform(0.0, math.tau)
         self._imbalance_force_kn = 0.0
         self._local_ti_multiplier = 1.0
+        self._wake_deficit = 0.0
         self._sim_time = 0.0
         self._generated_power_kw = 0.0
         self._generator_speed = 0.0
@@ -316,10 +317,12 @@ class TurbinePhysicsModel:
              grid_frequency_ref: Optional[float] = None,
              grid_voltage_ref: Optional[float] = None,
              ambient_humidity_pct: float = 65.0,
-             local_ti_multiplier: float = 1.0) -> Dict[str, float]:
+             local_ti_multiplier: float = 1.0,
+             wake_deficit: float = 0.0) -> Dict[str, float]:
         """Advance the turbine physics simulation by one timestep and return all SCADA tag values."""
         s = self.spec
         self._local_ti_multiplier = max(0.0, float(local_ti_multiplier))
+        self._wake_deficit = max(0.0, min(0.70, float(wake_deficit)))
         self._sim_time += dt
         self._update_grid_reference(dt, grid_frequency_ref, grid_voltage_ref)
         fault_physics = self._get_fault_physics()
@@ -703,6 +706,7 @@ class TurbinePhysicsModel:
             "WMET_TmpOutside": round(ambient_temp, 2),
             "WMET_HumOutside": round(self.cooling.last_ambient_humidity, 2),
             "WMET_LocalTi": round(self._local_ti_multiplier * 100.0, 1),
+            "WMET_WakeDef": round(self._wake_deficit * 100.0, 2),
             "WNAC_NacTmp": temps["nacelle"],
             "WNAC_NacCabTmp": temps["nac_cabinet"],
             "WNAC_VibMsNacXDir": round(vib_x, 3),
@@ -1043,6 +1047,7 @@ class TurbinePhysicsModel:
         self._rotor_azimuth = self._rng.uniform(0.0, math.tau)
         self._imbalance_force_kn = 0.0
         self._local_ti_multiplier = 1.0
+        self._wake_deficit = 0.0
         self._sim_time = 0.0
         self._generated_power_kw = 0.0
         self._generator_speed = 0.0

--- a/simulator/physics/wind_field.py
+++ b/simulator/physics/wind_field.py
@@ -347,10 +347,12 @@ class PerTurbineWind:
     def __init__(self, turbine_count: int, seed: int = 0,
                  positions: Optional[List[TurbinePosition]] = None,
                  spacing_m: float = 500.0,
-                 wind_shear_exponent: float = 0.2):
+                 wind_shear_exponent: float = 0.2,
+                 rotor_diameter: float = 70.65):
         self._rng = np.random.RandomState(seed)
         self._count = turbine_count
         self.wind_shear_exponent = wind_shear_exponent
+        self._rotor_diameter = rotor_diameter
 
         # Turbine positions
         self._positions = positions or default_farm_layout(turbine_count, spacing_m)
@@ -358,6 +360,7 @@ class PerTurbineWind:
         # Persistent per-turbine characteristics
         self._offsets = self._rng.normal(0, 0.35, turbine_count)
         self._wake_factors = np.ones(turbine_count)
+        self._wake_deficits = np.zeros(turbine_count)  # reported fraction 0..1
 
         # Per-turbine turbulence generators for spatial decorrelation
         self._turb_gens = [TurbulenceGenerator(seed=seed + 1000 + i) for i in range(turbine_count)]
@@ -384,8 +387,8 @@ class PerTurbineWind:
         """
         self._current_direction = wind_direction
 
-        # Update wake factors based on current wind direction
-        self._update_wake_factors(wind_direction)
+        # Update wake factors based on current wind direction, speed, and TI
+        self._update_wake_factors(wind_direction, farm_wind, turbulence_intensity)
 
         # Generate natural wind events stochastically
         self._propagation.generate_natural_events(farm_wind, dt)
@@ -429,6 +432,11 @@ class PerTurbineWind:
         """Effective TI multiplier (1.0 = baseline) at a turbine location."""
         idx = min(turbine_index, self._count - 1)
         return float(self._current_ti_multipliers[idx])
+
+    def get_wake_deficit(self, turbine_index: int) -> float:
+        """Wake deficit fraction at a turbine (0.0 = free stream, 0.6 = deep wake)."""
+        idx = min(turbine_index, self._count - 1)
+        return float(self._wake_deficits[idx])
 
     def _update_turbulence_pockets(self, farm_wind: float, dt: float):
         """Spawn / expire pockets and compute per-turbine TI multipliers."""
@@ -476,44 +484,96 @@ class PerTurbineWind:
                 weight = math.exp(-(dx * dx + dy * dy) / max(r2, 1.0))
                 self._current_ti_multipliers[i] += boost * weight
 
-    def _update_wake_factors(self, wind_direction: float):
-        """Compute direction-aware wake factors.
+    def _update_wake_factors(self, wind_direction: float,
+                             mean_wind: float = 10.0,
+                             turbulence_intensity: float = 0.08):
+        """Compute direction-aware wake factors using Bastankhah-Porté-Agel.
 
-        Turbines downwind of others lose 2-8% of wind speed.
-        Wake strength depends on alignment with wind direction.
+        Gaussian wake model (Bastankhah & Porté-Agel, Renew. Energy 70, 2014):
+            ε/D    = 0.25 · √((1 + √(1 − Ct)) / (2·√(1 − Ct)))
+            σ(x)/D = k* · (x/D) + ε/D
+            C(x)   = 1 − √(1 − Ct / (8·(σ/D)²))
+            ΔU/U   = C(x) · exp(−0.5·(r/σ)²)
+
+        Wake expansion rate (Niayifar & Porté-Agel 2016):
+            k* ≈ 0.38 · TI + 0.004  (≈0.04 at TI=0.1, typical offshore)
+
+        Multiple wakes are superposed via sum-of-squares of deficits.
         """
         angle_rad = math.radians(wind_direction)
         wind_dx = -math.sin(angle_rad)  # wind blows FROM this direction
         wind_dy = -math.cos(angle_rad)
 
         n = self._count
-        self._wake_factors = np.ones(n)
+        D = float(self._rotor_diameter)
 
-        for i in range(n):
+        # Operating Ct heuristic: peaks near V≈8 m/s (Region 2), drops above rated
+        V_rated = 11.0
+        if mean_wind < 3.0:
+            ct = 0.0
+        elif mean_wind < V_rated:
+            # Near-peak momentum extraction in Region 2
+            ct = 0.82 - 0.015 * abs(mean_wind - 8.0)
+        else:
+            # Pitched rotor above rated: Ct drops with (V_rated/V)²
+            ct = 0.82 * (V_rated / mean_wind) ** 2
+        ct = max(0.05, min(0.90, ct))
+
+        # Near-wake offset ε/D (Bastankhah eq. 7)
+        one_minus_ct = max(0.01, 1.0 - ct)
+        sqrt_one_minus_ct = math.sqrt(one_minus_ct)
+        eps_over_D = 0.25 * math.sqrt(
+            (1.0 + sqrt_one_minus_ct) / (2.0 * sqrt_one_minus_ct)
+        )
+
+        # TI-dependent wake expansion rate (Niayifar & Porté-Agel 2016)
+        k_star = max(0.02, 0.38 * max(turbulence_intensity, 0.02) + 0.004)
+
+        # Pre-compute Ct/8 for deficit discriminant
+        ct_over_8 = ct / 8.0
+
+        # Accumulate sum-of-squares deficits for each downstream turbine
+        deficits_sq = np.zeros(n)
+
+        if ct >= 0.05 and mean_wind > 2.0:
             for j in range(n):
-                if i == j:
-                    continue
-                # Vector from j to i
-                dx = self._positions[i].x - self._positions[j].x
-                dy = self._positions[i].y - self._positions[j].y
-                dist = math.sqrt(dx * dx + dy * dy)
-                if dist < 10.0:
-                    continue
+                xj = self._positions[j].x
+                yj = self._positions[j].y
+                for i in range(n):
+                    if i == j:
+                        continue
+                    dx = self._positions[i].x - xj
+                    dy = self._positions[i].y - yj
+                    # Downstream distance (along wind travel direction)
+                    x_down = dx * wind_dx + dy * wind_dy
+                    if x_down <= 0.5 * D:
+                        continue  # upstream or abreast of j → no wake
+                    # Cross-stream (perpendicular to wind) squared distance
+                    r_sq = max(0.0, dx * dx + dy * dy - x_down * x_down)
 
-                # How aligned is j→i with wind direction?
-                # cos_angle = 1.0 means i is directly downwind of j
-                cos_angle = (dx * wind_dx + dy * wind_dy) / dist
-                if cos_angle < 0.3:
-                    continue  # Not in wake zone
+                    # Wake half-width at x_down
+                    sigma_over_D = k_star * (x_down / D) + eps_over_D
+                    sigma_sq_over_D_sq = sigma_over_D * sigma_over_D
 
-                # Wake deficit: stronger when directly aligned, weaker at distance
-                # Jensen/Park-like simple model
-                alignment = max(0.0, (cos_angle - 0.3) / 0.7)
-                wake_deficit = 0.08 * alignment * (200.0 / max(dist, 200.0)) ** 0.5
-                self._wake_factors[i] *= (1.0 - wake_deficit)
+                    # Max deficit (wake centerline). Need discriminant > 0.
+                    discriminant = 1.0 - ct_over_8 / max(sigma_sq_over_D_sq, 1e-6)
+                    if discriminant <= 0.0:
+                        # Deep near-wake: cap at a physical upper bound
+                        c_max = 0.70
+                    else:
+                        c_max = 1.0 - math.sqrt(discriminant)
 
-        # Clamp to reasonable range
-        self._wake_factors = np.clip(self._wake_factors, 0.85, 1.0)
+                    # Gaussian radial profile
+                    sigma_m_sq = sigma_sq_over_D_sq * D * D
+                    radial = math.exp(-0.5 * r_sq / max(sigma_m_sq, 1.0))
+                    deficit = c_max * radial
+
+                    deficits_sq[i] += deficit * deficit
+
+        # Sum-of-squares superposition: total deficit fraction
+        total_deficit = np.sqrt(deficits_sq)
+        self._wake_deficits = np.clip(total_deficit, 0.0, 0.70)
+        self._wake_factors = 1.0 - self._wake_deficits
 
     @staticmethod
     def blade_shear_ratio(hub_height: float, rotor_radius: float,


### PR DESCRIPTION
## Summary

Replace the simplified Jensen/Park top-hat wake model with the Bastankhah-Porté-Agel (2014) Gaussian wake model, which is the industry-standard analytical wake model. This upgrade couples wake deficits to thrust coefficient (Ct), adds TI-dependent wake expansion, implements proper Gaussian radial profiles, and uses sum-of-squares superposition for multiple wakes.

## Key Changes

### Physics Model (`simulator/physics/wind_field.py`)
- **`PerTurbineWind.__init__`**: Added `rotor_diameter` parameter (default 70.65 m) and `_wake_deficits` state array
- **`_update_wake_factors()` rewrite**: 
  - Implements Bastankhah-Porté-Agel equations:
    - Near-wake offset: ε/D = 0.25 × √((1 + √(1 − Ct)) / (2√(1 − Ct)))
    - Linear expansion: σ(x)/D = k* × (x/D) + ε/D
    - Max deficit: C(x) = 1 − √(1 − Ct / (8·(σ/D)²))
    - Radial Gaussian: ΔU/U = C(x) × exp(−0.5·(r/σ)²)
  - Ct heuristic: peaks at ~0.82 in Region 2 (3–11 m/s), drops with (V_rated/V)² above rated
  - TI-dependent expansion rate: k* = max(0.02, 0.38·TI + 0.004) per Niayifar & Porté-Agel 2016
  - Downstream distance threshold: x_down ≤ 0.5·D excluded from wake effects
  - Deep near-wake handling: caps C_max at 0.70 when discriminant ≤ 0
  - Multi-wake superposition via sum-of-squares: total_deficit = √(Σ deficit_i²)
- **New public method**: `get_wake_deficit(turbine_index)` returns wake deficit fraction (0.0–0.70)
- **Updated `step()` signature**: passes `farm_wind` and `turbulence_intensity` to `_update_wake_factors()`

### Integration (`simulator/engine.py`, `simulator/physics/turbine_physics.py`)
- **`engine.py`**: Retrieves `get_wake_deficit(idx)` and passes to `turbine.step()`
- **`turbine_physics.py`**:
  - Added `_wake_deficit` state variable (initialized to 0.0)
  - Extended `step()` signature with `wake_deficit: float = 0.0` parameter
  - Clamps wake_deficit to [0.0, 0.70]
  - Outputs new SCADA tag `WMET_WakeDef` (wake velocity deficit %)

### SCADA Registry (`simulator/physics/scada_registry.py`)
- Added `WMET_WakeDef` tag: REAL32, %, range 0–70, "Wake Velocity Deficit" / "尾流風速赤字"

### Documentation
- Updated `docs/daily_report.md` and `docs/physics_model_status.md` with model details and validation results
- Updated `README.md` and `CLAUDE.md` to reflect 95 SCADA tags (was 94)
- Updated `TODO.md` with completion marker

## Validation

Self-tested scenarios:
- 3-turbine linear array (500 m spacing, 10 m/s, TI=0.08): upstream 0%, downstream 17–19% deficit ✓
- Side-wind (0°): all turbines 0% deficit ✓
- High wind (16 m/s, Region 3): deficit drops to 12–14% due to lower Ct ✓
- High T

https://claude.ai/code/session_01Qb5XstSavokxtiSxfsT6Yh