### PR TITLE
feat: atmospheric stability couples diurnal cycle to shear α and TI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Current Position
 
-A working wind farm simulation platform with 97 SCADA tags, comprehensive physics models, and full API access for external data consumers.
+A working wind farm simulation platform with 99 SCADA tags, comprehensive physics models, and full API access for external data consumers.
 
 Platform includes:
 - backend REST + WebSocket APIs (40+ endpoints)
@@ -33,6 +33,7 @@ Primary focus (next improvements):
 - wake model upgrade — fixed: Bastankhah-Porté-Agel Gaussian wake (TI-dependent expansion, Ct-coupled deficit, sum-of-squares superposition), observable via `WMET_WakeDef` — see #93
 - dynamic wake meandering — fixed: Larsen-DWM AR(1) lateral oscillation of wake centerline (σ_θ≈0.3·TI, τ≈25 s), downstream `WMET_WakeDef` now has realistic time variability — see #95
 - yaw-induced wake deflection (wake steering) — fixed: Bastankhah 2016 θ_c = 0.3·γ·(1−√(1−Ct·cos γ))/cos γ coupled to per-turbine yaw_error, new `WMET_WakeDefl` tag — see #97
+- atmospheric stability / diurnal shear-TI coupling — fixed: continuous score s=solar·wind_damping·cloud_damping drives α ∈ [0.04, 0.30] and TI multiplier ∈ [0.5, 1.6], new `WMET_ShearAlpha` / `WMET_AtmStab` tags — see #99
 
 Secondary focus:
 - deployment hardening (JWT, Docker) — only when ready to share externally
@@ -75,6 +76,7 @@ Still pending or incomplete:
 - wake model (Bastankhah-Porté-Agel Gaussian) — done: TI-dependent expansion, Ct-coupled max deficit, sum-of-squares superposition + `WMET_WakeDef` tag (#93)
 - dynamic wake meandering — done: Larsen-DWM lateral AR(1) oscillation (σ_θ=0.3·TI, τ=25 s) applied to source wake centerline, new `WMET_WakeMndr` tag (#95)
 - yaw-induced wake deflection — done: Bastankhah 2016 skew angle coupled to per-turbine yaw_error, new `WMET_WakeDefl` tag (#97)
+- atmospheric stability / diurnal shear-TI coupling — done: Monin-Obukhov-simplified score s drives α ∈ [0.04, 0.30] and TI multiplier ∈ [0.5, 1.6], new `WMET_ShearAlpha` + `WMET_AtmStab` tags (#99)
 - SQLite vs time-series DB architecture decision — see #24
 - dependency security vulnerabilities (cryptography, pyjwt, etc.) — see #48
 - no automated test suite (pytest) — see #52

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Wind farm monitoring and digital twin platform with:
 - physics-based wind turbine simulation
-- 97 SCADA tags aligned to Bachmann Z72 definitions
+- 99 SCADA tags aligned to Bachmann Z72 definitions
 - fault injection and degradation scenarios
 - wind and grid condition control
 - Modbus TCP simulation
@@ -237,6 +237,7 @@ Historical storage currently grows continuously and does not yet have a cleanup 
 - wake model upgraded to Bastankhah-Porté-Agel Gaussian (TI-dependent expansion, Ct-coupled deficit, sum-of-squares superposition, `WMET_WakeDef` tag) — see #93
 - dynamic wake meandering implemented (Larsen-DWM lateral AR(1) oscillation of wake centerline, σ_θ=0.3·TI, τ≈25 s, new `WMET_WakeMndr` SCADA tag) — see #95
 - yaw-induced wake deflection implemented (Bastankhah 2016 θ_c initial skew, per-source δ_y(x)=tan(θ_c)·x coupled to yaw_error, new `WMET_WakeDefl` SCADA tag; driven by yaw_misalignment fault and transient yaw lag) — see #97
+- atmospheric stability / diurnal shear-TI coupling implemented (Monin-Obukhov-simplified continuous stability score s ∈ [−1, +1] from solar time × wind mechanical mixing × cloud damping; drives wind shear exponent α ∈ [0.04, 0.30] and turbulence intensity multiplier ∈ [0.5, 1.6]; new `WMET_ShearAlpha` + `WMET_AtmStab` SCADA tags) — see #99
 - full protection relay coordination not yet implemented
 - frontend RUL visualization pending (fatigue alarm thresholds, RUL estimation, and alarm event integration implemented — see #57)
 - dependency security vulnerabilities pending upgrade (see #48)

--- a/TODO.md
+++ b/TODO.md
@@ -55,6 +55,8 @@
 - [x] 96 SCADA tags total (was 95): +1 wake meander lateral offset tag (`WMET_WakeMndr`)
 - [x] Yaw-induced wake deflection (Bastankhah 2016 θ_c=0.3·γ·(1−√(1−Ct·cos γ))/cos γ initial skew, δ_y(x)=tan(θ_c)·x applied per-source inside Bastankhah Gaussian r_lat, engine feeds per-turbine yaw_error back each step, ±45° clamp) — see #97
 - [x] 97 SCADA tags total (was 96): +1 yaw-induced wake deflection tag (`WMET_WakeDefl`)
+- [x] Atmospheric stability / diurnal shear-TI coupling (continuous score s=solar·wind_damping·cloud_damping, α=0.14−0.10·s clamped [0.04, 0.30], TI_mult=1+0.5·s clamped [0.5, 1.6], strong-wind mechanical mixing, override-neutral, per-turbine α offset renamed) — see #99
+- [x] 99 SCADA tags total (was 97): +2 atmospheric stability tags (`WMET_ShearAlpha`, `WMET_AtmStab`)
 
 ### Backend
 - [x] FastAPI REST APIs
@@ -188,6 +190,7 @@ These parts are implemented, but still first-generation models:
 - [x] Wake model upgrade: Bastankhah-Porté-Agel Gaussian wake (replaces simplified Jensen top-hat); TI-dependent expansion, Ct-coupled deficit, sum-of-squares multi-wake superposition, exposed via `WMET_WakeDef` — see #93
 - [x] Dynamic wake meandering: Larsen-DWM AR(1) lateral oscillation applied per source (σ_θ=0.3·TI, τ=25 s), downstream `WMET_WakeDef` now has realistic time variability, new `WMET_WakeMndr` tag — see #95
 - [x] Yaw-induced wake deflection: Bastankhah 2016 initial skew θ_c=0.3·γ·(1−√(1−Ct·cos γ))/cos γ, δ_y(x)=tan(θ_c)·x coupled per-source; engine feeds per-turbine yaw_error back each step; new `WMET_WakeDefl` tag — see #97
+- [x] Atmospheric stability / diurnal shear-TI coupling: Monin-Obukhov-simplified continuous score s ∈ [−1, +1] from solar time × mechanical mixing × cloud damping; drives α (0.04–0.30) and TI multiplier (0.5–1.6); new `WMET_ShearAlpha` + `WMET_AtmStab` tags — see #99
 
 ### Deployment (low priority — lab-only use currently)
 - [ ] JWT authentication

--- a/docs/daily_report.md
+++ b/docs/daily_report.md
@@ -1,25 +1,26 @@
 # digiWindFarm Daily Report
 
-> 最後更新：2026-04-21
+> 最後更新：2026-04-22
 
 ## 今日 Commit 摘要
 
-本次日報工作提交（分支 `claude/keen-hopper-5UKdM`）：
-- feat: add yaw-induced wake deflection (Bastankhah 2016 wake steering) (#97)
+本次日報工作提交（分支 `claude/keen-hopper-ujMjS`）：
+- feat: atmospheric stability couples diurnal cycle to shear α and TI (#99)
 
 近 24 小時主幹 `main` 合併摘要：
+- [d5b9adb] Merge PR #98 — 偏航引發尾流偏轉文件同步
+- [f96ec88] docs: update project docs and daily report for yaw-induced wake deflection (#97)
+- [8d520c8] feat: add yaw-induced wake deflection (Bastankhah 2016 wake steering) (#97)
 - [ea9ffae] Merge PR #96 — 動態尾流蜿蜒文件同步
 - [bf24c3a] docs: update project docs and daily report for dynamic wake meandering (#95)
-- [1cb1a1b] feat: add dynamic wake meandering with lateral wake-center AR(1) oscillation (#95)
-- [8eaa075] Merge PR #94 — Bastankhah-Porté-Agel 尾流模型（#93）
-- [af902a0] feat: upgrade wake model to Bastankhah-Porté-Agel Gaussian (#93)
 
 ## Issue 狀態
 
 | 動作 | Issue # | 標題 | 說明 |
 |------|---------|------|------|
-| 建立 | #97 | 偏航引發之尾流側向偏轉（wake steering）— Bastankhah 2016 | 今日建立並實作 |
-| 實作 | #97 | 偏航引發之尾流側向偏轉 | `WMET_WakeDefl` 新標籤，7 項自測全過 |
+| 建立 | #99 | 大氣穩定度 Monin-Obukhov — 日週期風切指數 α 與亂流強度 TI 耦合 | 今日建立並實作 |
+| 實作 | #99 | 大氣穩定度日週期耦合 | 新增 `WMET_ShearAlpha` + `WMET_AtmStab`，5 項自測全過 |
+| 保持 | #97 | 偏航引發尾流偏轉 | 昨日已實作並合併 main |
 | 保持 | #67 | 完整保護繼電器協調 LVRT/OVRT | 電壓-時間保護曲線 |
 | 保持 | #58 | 頻譜振動警報閾值與邊帶分析 | 頻帶警報曲線仍待做 |
 | 保持 | #57 | 疲勞警報閾值與 RUL 估算 | 後端完成，前端 RUL 視覺化待做 |
@@ -31,13 +32,14 @@
 | 保持 | #26 | 部署強化 | Docker 已完成，JWT/RBAC 待做 |
 | 保持 | #24 | 歷史資料儲存架構 | 架構決策待定 |
 
-本日建立 1 個 issue（#97），符合「每次最多 3 個新 issue」規則。
+本日建立 1 個 issue（#99），符合「每次最多 3 個新 issue」規則。
 
 ## Open Issues 總覽
 
 | # | 標題 | Labels | 建立日期 | 備註 |
 |---|------|--------|----------|------|
-| #97 | 偏航引發尾流偏轉 — Bastankhah 2016 | enhancement, physics, auto-detected | 2026-04-21 | 已實作 |
+| #99 | 大氣穩定度 Monin-Obukhov 日週期耦合 | enhancement, physics, auto-detected | 2026-04-22 | 已實作 |
+| #97 | 偏航引發尾流偏轉 — Bastankhah 2016 | enhancement, physics, auto-detected | 2026-04-21 | 已合併 main |
 | #67 | 完整保護繼電器協調 LVRT/OVRT | enhancement, physics, auto-detected | 2026-04-16 | 電壓-時間曲線 |
 | #58 | 頻譜振動警報閾值與邊帶分析 | enhancement, physics, auto-detected | 2026-04-15 | 頻帶警報曲線待做 |
 | #57 | 疲勞警報閾值與 RUL 估算 | enhancement, physics, auto-detected | 2026-04-15 | 前端 RUL 待做 |
@@ -54,9 +56,9 @@
 | 模組 | 最後修改 | TODO 數 | 測試 | 備註 |
 |------|----------|---------|------|------|
 | `server/` | 2026-04-17 | 0 | 無測試套件 | 無變更 |
-| `simulator/` | 2026-04-21 | 0 | 無測試套件 | `engine.py` 新增 yaw_error 回饋 + `wake_yaw_deflection_m` |
-| `simulator/physics/` | 2026-04-21 | 0 | 無測試套件 | `wind_field.py` 新增 Bastankhah 偏航初始傾斜角；`turbine_physics`、`scada_registry` 新增 `WMET_WakeDefl` |
-| `wind_model.py`（根目錄） | 2026-04-19 | 0 | 無測試套件 | 無變更 |
+| `simulator/` | 2026-04-22 | 0 | 無測試套件 | `engine.py` 新增穩定度/α/TI_mult 計算與傳遞 |
+| `simulator/physics/` | 2026-04-22 | 0 | 無測試套件 | `turbine_physics` 接收 `wind_shear_exp_base`/`atm_stability` kwargs、`scada_registry` 新增 `WMET_ShearAlpha`/`WMET_AtmStab` |
+| `wind_model.py`（根目錄） | 2026-04-22 | 0 | 無測試套件 | 新增 `get_atmospheric_stability`/`get_shear_exponent`/`get_turbulence_multiplier` |
 | `frontend/` | 2026-04-17 | 0 | 無測試套件 | 無變更 |
 | 根目錄原型 | 2026-04-12 | 0 | — | 早期原型檔案 |
 
@@ -64,89 +66,126 @@
 
 共 58 個路由（57 HTTP + 1 WebSocket）。無新增路由。詳見 README.md「Core APIs」章節。
 
-待同步：`/api/farms`（4 個路由）仍未同步至 README 的 Core APIs 章節。
+待同步：`/api/farms`（10 個路由）仍未完整同步至 README 的 Core APIs 章節。
 
 ## 程式碼品質
 
 - Lint 錯誤：115（核心模組 `server/` + `simulator/` 維持 0 錯誤）
 - `ruff check simulator/ server/ wind_model.py` — All checks passed ✓
-- `python -m py_compile simulator/physics/{wind_field,turbine_physics,scada_registry}.py simulator/engine.py` — 4 個修改檔案全部通過
+- `python -m py_compile simulator/physics/{turbine_physics,scada_registry}.py simulator/engine.py wind_model.py` — 4 個修改檔案全部通過
 - Broken imports：0（核心模組全部通過）
 - 語法錯誤：0
 - 測試套件：未建立（無 pytest）— 追蹤 issue #52
 - 安全漏洞：17 個（5 個套件），詳見 #48
 - TODO/FIXME/HACK：0 個（核心模組）
-- SCADA 標籤：**97 個**（+1：`WMET_WakeDefl`）
+- SCADA 標籤：**99 個**（+2：`WMET_ShearAlpha`、`WMET_AtmStab`）
 
 ## 今日新增功能
 
-### 偏航引發之尾流側向偏轉 Yaw-induced Wake Deflection / Wake Steering（#97）
+### 大氣穩定度日週期耦合 Atmospheric Stability Coupling（#99）
 
 **物理原理**
 
-#93（Bastankhah-Porté-Agel 高斯尾流）假設風機完全對齊來流風向，但真實風場中：
+離岸/陸上邊界層有強烈的**日週期穩定度循環**，這是所有長期量測資料共同觀察到的現象：
 
-1. **瞬時偏航誤差**：`yaw_model.py` 設計 15° 死區 + 60 s 啟動延遲，風向變化時 `yaw_error` 可達 10–15°
-2. **`yaw_misalignment` 故障**：注入最多 20°·severity 的固定偏差
-3. **主動尾流導向**：現代風場控制策略會**故意**讓上游風機偏航 10–25° 以減少下游赤字
+| 時段 | 穩定度 | 典型 α | 典型 TI | 物理成因 |
+|------|-------|-------|---------|----------|
+| 深夜/清晨 | 強穩定 | 0.25–0.35 | 0.05–0.08 | 地表輻射冷卻 → 近地層溫度反轉 → 抑制垂直混合 |
+| 日出/日落 | 中性 | 0.14 | 0.10 | 熱平衡過渡期 |
+| 正午/午後 | 強不穩定 | 0.06–0.12 | 0.12–0.18 | 太陽加熱地表 → 熱浮力 → 激烈垂直混合 |
+| 強風或陰天 | 機械/中性 | 趨近 0.14 | 趨近 0.10 | 機械混合或雲層削弱日射效應 |
 
-偏航時，轉子推力向量具備側向分量，尾流中心軸隨下游距離持續偏轉。
-
-Bastankhah & Porté-Agel (2016, JFM) 給出初始傾斜角解析解：
-
+使用連續穩定度分數 `s ∈ [−1, +1]`：
 ```
-θ_c(γ, Ct) = 0.3 · γ · (1 − √(1 − Ct · cos γ)) / cos γ      (弧度)
-δ_y(x)     ≈ tan(θ_c) · x_down                              (近尾流線性)
+s = solar(t) × wind_damping(V) × cloud_damping(pressure)
+
+solar(t)       = sin(π · (hour − 6)/12)               # +1 正午、0 晨昏、−1 午夜
+wind_damping   = 1 / (1 + (V/8)²)                      # 強風機械混合壓低 |s|
+cloud_damping  = 1 − 0.5 · max(0, −pressure_state)     # 低壓鋒面雲層削弱
+```
+
+對應風切與 TI：
+```
+α(s)      = clamp(0.14 − 0.10·s, 0.04, 0.30)
+TI_mult(s)= clamp(1.0 + 0.5·s,   0.5,  1.6)
 ```
 
 **實作方式**
 
-1. `simulator/physics/wind_field.py::PerTurbineWind`：
-   - `__init__` 新增 `_yaw_misalignment_rad`、`_yaw_tan_theta_c` 向量
-   - `set_yaw_misalignments(angles_rad)`：引擎每步餵入 per-turbine yaw_error（弧度），clamp 至 ±45°
-   - `_update_wake_factors` 預先計算 `tan_theta_c[j]`，於內層 r_lat 計算中再加一項 `−tan_theta_c[j] · x_down`（與既有尾流蜿蜒 `−θ_m[j]·x_down` 共用同一個側向軸）
-   - `get_wake_yaw_deflection_offset(idx)`：回傳該台風機自身尾流於 3D 參考位置之側向偏轉（m）
-2. `simulator/physics/turbine_physics.py`：
-   - `step()` 新增 `wake_yaw_deflection_m: float = 0.0` kwarg（±80 m clamp 做保護）
-   - `__init__` 與 `reset()` 初始化 `_wake_yaw_deflection_m`
-   - SCADA 輸出新增 `"WMET_WakeDefl": round(self._wake_yaw_deflection_m, 2)`
-3. `simulator/physics/scada_registry.py`：新增 `ScadaTag("WMET_WakeDefl", ..., "REAL32", "m", ..., -50, 50)`
-4. `simulator/engine.py`：
-   - `_last_yaw_err_rad` 向量儲存上一步 yaw_error（rad）
-   - 下一步 `_per_turbine_wind.step()` 前呼叫 `set_yaw_misalignments(...)`
-   - 每步取 `get_wake_yaw_deflection_offset(idx)` 傳給 `turbine.step`
-   - 每台 `turbine.step` 後讀取 `scada_output["WYAW_YwVn1AlgnAvg5s"]`（度）轉弧度存入 `_last_yaw_err_rad[idx]`
+1. `wind_model.py::WindEnvironmentModel`：
+   - `get_atmospheric_stability(timestamp)` → 連續分數 [-1, +1]
+     - 手動 override 時回 0.0（中性）
+     - 無副作用：重構為使用 `_weather._pressure_state` 直接讀取，不再呼叫 `_get_auto_wind`，每步可多次呼叫而不改變 RNG 狀態
+   - `get_shear_exponent(timestamp, stability=None)` → α
+   - `get_turbulence_multiplier(timestamp, stability=None)` → TI 倍率
+   - 新的 `stability` 可選參數允許呼叫端預先計算 s 後共享，避免重複計算
+
+2. `simulator/engine.py`：
+   - 每步計算 `atm_stability` 一次，然後傳入 `get_shear_exponent(stability=s)` 與 `get_turbulence_multiplier(stability=s)` 避免重複
+   - `effective_ti = wind_model.turbulence_intensity × TI_mult`
+   - 同時餵給 `_turbulence_gen.step(ti=effective_ti)` 與 `_per_turbine_wind.step(..., effective_ti, ...)`
+   - 每台風機 `turbine.step(..., wind_shear_exp_base=shear_alpha, atm_stability=atm_stability)`
+
+3. `simulator/physics/turbine_physics.py`：
+   - `step()` 新增 `wind_shear_exp_base: float = 0.2` 與 `atm_stability: float = 0.0` kwargs
+   - `_individuality` 的 `wind_shear_exp` 鍵**重新命名**為 `wind_shear_exp_offset`，語意從「絕對 α」改為「永久偏置」（±0.04~+0.06）
+   - `_effective_shear_alpha = clamp(wind_shear_exp_base + offset, 0.04, 0.35)`，用於 1P 風切扭矩調變與疲勞計算
+   - `__init__` 與 `reset()` 初始化新狀態 `_effective_shear_alpha`、`_atm_stability`
+   - SCADA 輸出新增 `"WMET_ShearAlpha"` 與 `"WMET_AtmStab"`
+
+4. `simulator/physics/scada_registry.py`：
+   - 新增 `ScadaTag("WMET_ShearAlpha", ..., "REAL32", "-", ..., 0.0, 0.4)`
+   - 新增 `ScadaTag("WMET_AtmStab", ..., "REAL32", "-", ..., -1.0, 1.0)`
+   - **SCADA 總數從 97 增為 99**
 
 **物理效應（自測驗證）**
 
-3 台風機 E-W 線列（0、500、1000 m），rotor D=70.65 m，V=8 m/s、TI=0.08、burn-in 100 s + 取樣 400 s：
+`WindEnvironmentModel(seed=42)`，2026-04-22：
 
-| 檢核項目 | 預期 | 實測 |
-|----------|------|------|
-| γ=0° 偏轉量 | 0 m（不應影響 #93 基線） | 0.00 m（3 台全部）✓ |
-| γ=+15° 偏轉 @3D（Bastankhah 解析式） | 9.38 m | **9.38 m**（誤差 <0.5 m）✓ |
-| γ=+15° 下游 T1 赤字 | 顯著下降 | 16.84% → 14.66%（↓12.9%）✓ |
-| γ=+25° 偏轉 @3D | > 15 m（非線性單調增） | 15.12 m ✓ |
-| γ=+25° T1 赤字 | 再下降 | 11.71%（vs γ=0 的 16.84% ↓30.4%）✓ |
-| γ=−15° 偏轉鏡射 | −9.38 m | −9.38 m ✓ |
-| γ=−15° T1 赤字 | 亦下降 | 14.56% < 16.84% ✓ |
-| γ=60° 輸入 clamp | 45° | 45.00° ✓ |
-| 源風機 T0 無自尾流 | 0% | 0.00% ✓ |
+| 時段 | 預期 s | 實測 s | α | TI_mult | 結果 |
+|------|--------|--------|---|---------|------|
+| 02:00（夜） | s ≤ −0.35 | **−0.459** | 0.186 | 0.770 | ✓ |
+| 06:00（晨） | s ≈ 0 | **+0.000** | 0.140 | 1.000 | ✓ |
+| 13:00（午） | s ≥ 0.35 | **+0.512** | 0.089 | 1.256 | ✓ |
+| 18:00（昏） | s ≈ 0 | **+0.000** | 0.140 | 1.000 | ✓ |
+| 21:00（夜） | 負 | **−0.422** | 0.182 | 0.789 | ✓ |
+| 手動 override 8 m/s@noon | s=0 強制中性 | **0.000** | 0.140 | 1.000 | ✓ |
+| V=20 m/s 機械混合 | wind_damping ≤ 0.15 | **0.138** | — | — | ✓ |
+
+Engine 端整合：
+- 3 台風機在同一步同時收到共用的 `atm_stability`（已追溯至 turbine.step 的 kwargs，完全一致）
+- per-turbine α 結構性差異保留（spread 0.07–0.12，由 `wind_shear_exp_offset` 驅動）
+- SCADA 輸出 `WMET_AtmStab`/`WMET_ShearAlpha` 在前後兩步之間平滑變化（無瞬跳）
 
 **影響範圍**
 
-- `yaw_misalignment` 故障（severity=1.0 → 20° 偏航）現在會**真實**地把尾流側推離下游風機，下游 `WMET_WakeDef` 會於數秒內下降並持續，故障清除後逐漸回到對齊狀態
-- 瞬時偏航（風向變化時的 `yaw_error`，典型 5–15°）會帶來 2–9 m 的下游尾流偏移 — 與實測 LiDAR 一致
-- 新 SCADA 標籤 `WMET_WakeDefl` 可於歷史圖表觀察每台風機的尾流自偏轉（±15 m 典型）
-- 與 #93（Bastankhah 赤字）、#95（蜿蜒）共用同一個 `r_lat` 側向軸：三者物理一致疊加
-- 未來主動尾流導向控制策略（wake steering control）有物理基礎可建立
+- **風切 α** 現在依時間變動，而不是固定 0.2：夜間 α 升到 0.18–0.22，白天降至 0.08–0.11。這會直接反映在 #71 的 1P 葉片扭矩調變和 #72 的葉片疲勞計算上
+- **TI_mult** 直接乘上基準 `turbulence_intensity`：夜間亂流下降到 60–80%，白天放大到 120–140%。會影響：
+  - #95 動態尾流蜿蜒（σ_θ=0.3·TI 之基線變動）
+  - #93 Bastankhah 尾流擴展率（k*=0.38·TI+0.004）
+  - 全場每步的湍流分量（`_turbulence_gen`）與每台風機的永久湍流（`_per_turbine_wind._turb_gens`）
+- 新 SCADA 標籤 `WMET_ShearAlpha`、`WMET_AtmStab` 可於歷史圖表觀察 24 小時週期，或用於後續故障診斷的「日週期基線校正」
+- 與 #89（濕度）、#91（局部亂流）、#93/#95/#97（尾流）共用 `WindEnvironmentModel` 的 `_weather._pressure_state` 軌跡，所以天氣鋒面會**同時**影響風切/TI、濕度、尾流 — 系統性自洽
+
+**為何這是物理「因」而非輸出偏移**
+
+- 根源於時間（日週期）與環境（風速、雲量）的真實物理驅動
+- 經由 α、TI 兩個**已存在**的物理參數路徑傳遞到所有下游模型（風切葉片負載、尾流擴展、湍流產生器）
+- 每台風機仍有**永久 α 偏置**（`wind_shear_exp_offset`）疊加在時變基線之上：持續差異 + 時間過渡雙重觀察
+- 手動 override 自動切回中性，避免 demo 時穩定度「莫名其妙變動」
 
 ## 建議行動
 
-1. **長時段資料品質驗證**：以 `examples/data_quality_analysis.py` 跑 2 h 混合工況，注入 `yaw_misalignment` 故障，觀察下游 `WMET_WakeDef` 的下降量是否 ~2–5%，並對應 `WMET_WakeDefl` 的時間軌跡
-2. **前端視覺化整合**：Dashboard 尾流熱圖同時顯示 DWM 蜿蜒 + 偏航偏轉的綜合瞬時中心線
+1. **長時段資料品質驗證**：以 `examples/data_quality_analysis.py` 跑 24 h 自動模式（time_scale=60），觀察：
+   - `WMET_AtmStab` 是否呈現日週期正弦波
+   - `WMET_ShearAlpha` 夜間是否 0.18–0.22、白天是否 0.08–0.11
+   - 塔架疲勞損傷率是否夜間升高（高剪切 → 1P 負載放大）
+2. **前端視覺化**：Dashboard 可新增穩定度熱圖或時間軸，標註白天/夜間區段
 3. **實作 #58 頻譜警報曲線**：前端顯示各頻帶警報閾值
 4. **實作 #57 前端 RUL 視覺化**：後端已就緒
-5. **建立 pytest 測試套件（#52）**：Bastankhah 傾斜角 + δ_y(x)=tan(θ_c)·x 的解析檢核為理想首批物理測試案例
-6. **主動 wake steering 控制實驗**：在模擬器層開放 API 注入 intentional yaw offset，驗證風場總出力的 wake-steering gain（可對比 NREL FLORIS 基準）
-7. **同步 `/api/farms` 4 個路由至 README.md**：仍未完成
+5. **建立 pytest 測試套件（#52）**：α(s)、TI_mult(s)、override 中性化為理想首批單元測試案例
+6. **未來擴充**：
+   - 海氣溫差（Sea-Air ΔT）驅動穩定度（目前用 `_pressure_state` 作代理）
+   - Low-level Jet（LLJ）夜間風速剖面
+   - 風切與葉片飛彈負載的非對稱性（轉子上下半部 V² 差異）
+7. **同步 `/api/farms` 10 個路由至 README.md**：仍未完成

--- a/docs/physics_model_status.md
+++ b/docs/physics_model_status.md
@@ -1,6 +1,6 @@
 # Physics Model Status
 
-Last updated: 2026-04-21 (yaw-induced wake deflection / wake steering)
+Last updated: 2026-04-22 (atmospheric stability / diurnal shear-TI coupling)
 
 This document tracks the current completion status of the wind turbine physics models.
 It is intended to be the single reference for:
@@ -356,6 +356,16 @@ Newly implemented:
 Newly implemented:
 - Yaw-induced wake deflection / wake steering (#97, Bastankhah & Porté-Agel 2016): for each source turbine j with yaw misalignment γ_j (=yaw_error, clamped ±45°), the initial skew angle is θ_c = 0.3·γ·(1−√(1−Ct·cos γ))/cos γ. Near-wake lateral deflection δ_y(x) = tan(θ_c)·x_down is added per-source to the signed cross-stream distance (alongside DWM meander). Engine captures per-turbine `WYAW_YwVn1AlgnAvg5s` each step and feeds it back to `PerTurbineWind.set_yaw_misalignments()` before the next wake update, so the `yaw_misalignment` fault and transient yaw lag both drive end-to-end wake steering. At γ=15°/Ct=0.82 the wake centerline deflects ~9.4 m @ 3D (exact closed-form match), ~22 m @ 500 m downstream. New SCADA tag `WMET_WakeDefl` (m, ±50).
 
+Newly implemented:
+- Atmospheric stability / diurnal shear-TI coupling (#99, Monin-Obukhov simplified): continuous stability score s ∈ [−1, +1] composed from solar(t) · wind_damping(V) · cloud_damping(pressure). Drives:
+  - wind shear exponent α = clamp(0.14 − 0.10·s, 0.04, 0.30) — nighttime 0.18–0.22, convective afternoon 0.08–0.11
+  - turbulence multiplier TI_mult = clamp(1.0 + 0.5·s, 0.5, 1.6) — applied to base TI in both the global and per-turbine turbulence generators
+  - Strong-wind regime (V > 15 m/s) damps |s| toward 0 (mechanical mixing)
+  - Low-pressure / frontal weather damps |s| toward 0 (cloud cover)
+  - Manual wind overrides force neutral s = 0
+  - per-turbine permanent α offset (±0.04–0.06) renamed to `wind_shear_exp_offset` and stacks on farm-level α
+  - New SCADA tags: `WMET_ShearAlpha` (α), `WMET_AtmStab` (s)
+
 Still missing:
 - curled-wake model for skewed inflow (yaw-deflection is handled via Bastankhah linear form; curled-wake adds counter-rotating vortex pair detail)
 
@@ -504,7 +514,7 @@ Implemented:
 - spectral vibration bands with fault-specific signatures
 - vibration alarm thresholds with ISO 10816-inspired zones
 - fatigue / load modeling (tower + blade moments, DEL, Miner's damage, alarm thresholds, RUL, tower SDOF dynamics)
-- 97 SCADA tags (electrical + vibration + structural load + alarm/RUL + bearing diagnostics + gear mesh sidebands + crest/kurtosis alarms + gearbox oil temp + tooth wear + outside humidity + local TI multiplier + Bastankhah wake deficit + wake meander offset + yaw-induced wake deflection)
+- 99 SCADA tags (electrical + vibration + structural load + alarm/RUL + bearing diagnostics + gear mesh sidebands + crest/kurtosis alarms + gearbox oil temp + tooth wear + outside humidity + local TI multiplier + Bastankhah wake deficit + wake meander offset + yaw-induced wake deflection + atmospheric stability + shear α)
 
 ### Still Weak
 - spectral alarm threshold curves — see #58 (crest factor/kurtosis anomaly alarms now completed)
@@ -535,4 +545,5 @@ Implemented:
 13. ~~Bastankhah-Porté-Agel Gaussian wake model~~ → done (#93, TI-dependent expansion + Ct-coupled deficit + sum-of-squares)
 14. ~~dynamic wake meandering (Larsen DWM)~~ → done (#95, AR(1) lateral wake centerline with σ_θ=0.3·TI, τ=25 s)
 15. ~~yaw-induced wake deflection / wake steering (Bastankhah 2016)~~ → done (#97, θ_c initial skew + δ_y(x)=tan(θ_c)·x, `WMET_WakeDefl`)
-16. deployment hardening (JWT auth, RBAC, Docker Compose)
+16. ~~atmospheric stability / diurnal shear-TI coupling~~ → done (#99, s ∈ [−1, +1] → α, TI_mult, `WMET_ShearAlpha`, `WMET_AtmStab`)
+17. deployment hardening (JWT auth, RBAC, Docker Compose)

--- a/simulator/engine.py
+++ b/simulator/engine.py
@@ -102,8 +102,17 @@ class WindFarmSimulator:
         grid_frequency = self.grid_model.get_frequency(sim_time)
         grid_voltage = self.grid_model.get_voltage(sim_time)
 
+        # Atmospheric stability couples diurnal cycle to shear α and TI (#99).
+        # Compute the stability score once; pass it to the shear / TI getters
+        # so we don't mutate the weather RNG state multiple times per step.
+        # Manual overrides return neutral values automatically.
+        atm_stability = self.wind_model.get_atmospheric_stability(sim_time)
+        shear_alpha = self.wind_model.get_shear_exponent(sim_time, stability=atm_stability)
+        ti_mult = self.wind_model.get_turbulence_multiplier(sim_time, stability=atm_stability)
+        effective_ti = max(0.0, self.wind_model.turbulence_intensity * ti_mult)
+
         turb_component = self._turbulence_gen.step(
-            base_wind, self.wind_model.turbulence_intensity, time_step
+            base_wind, effective_ti, time_step
         )
         farm_wind = max(0, base_wind + turb_component)
 
@@ -115,7 +124,7 @@ class WindFarmSimulator:
         # Advance wind field: per-turbine turbulence + event propagation
         self._per_turbine_wind.step(
             farm_wind, wind_direction,
-            self.wind_model.turbulence_intensity, time_step,
+            effective_ti, time_step,
         )
 
         # FaultEngine.step() advances severity progression and alarm tracking.
@@ -159,6 +168,8 @@ class WindFarmSimulator:
                 wake_deficit=wake_deficit,
                 wake_meander_offset_m=wake_meander_m,
                 wake_yaw_deflection_m=wake_yaw_defl_m,
+                wind_shear_exp_base=shear_alpha,
+                atm_stability=atm_stability,
             )
 
             # Capture yaw_error (deg) for this step; fed back next step to drive

--- a/simulator/physics/scada_registry.py
+++ b/simulator/physics/scada_registry.py
@@ -170,6 +170,14 @@ _TAGS: List[ScadaTag] = [
              "WMET", "REAL32", "m", "Wake Yaw-Induced Deflection @ 3D",
              "偏航引發尾流側向偏轉(3D 參考)",
              -50, 50),
+    ScadaTag("WMET_ShearAlpha", "WMET.Z72PLC__UI_Loc_WMET_Analogue_ShearAlpha",
+             "WMET", "REAL32", "-", "Wind Shear Exponent (power-law α)",
+             "風切指數 α",
+             0.0, 0.4),
+    ScadaTag("WMET_AtmStab", "WMET.Z72PLC__UI_Loc_WMET_Analogue_AtmStab",
+             "WMET", "REAL32", "-", "Atmospheric Stability Score (-1 stable..+1 unstable)",
+             "大氣穩定度分數(-1 穩定..+1 不穩定)",
+             -1.0, 1.0),
 
     # ══════════════════════════════════════════════════════════════════════
     # WNAC — Nacelle

--- a/simulator/physics/turbine_physics.py
+++ b/simulator/physics/turbine_physics.py
@@ -182,7 +182,10 @@ class TurbinePhysicsModel:
             "grid_ride_through_scale": 1.0 + self._rng.uniform(-0.22, 0.25),
             "grid_reconnect_delay": self._rng.uniform(-5.0, 8.0),
             "tower_shadow_amp": 0.12 + self._rng.uniform(-0.03, 0.03),
-            "wind_shear_exp": 0.2 + self._rng.uniform(-0.04, 0.06),
+            # Per-turbine permanent shear offset (±0.04–0.06) applied on top
+            # of the time-varying farm-level α from the atmospheric stability
+            # model (see #99). Legacy key `wind_shear_exp` removed.
+            "wind_shear_exp_offset": self._rng.uniform(-0.04, 0.06),
             "blade_mass_offsets": _blade_mass_offsets,
             "wind_veer_rate": 0.10 + self._rng.uniform(-0.03, 0.03),
         }
@@ -251,6 +254,10 @@ class TurbinePhysicsModel:
         self._wake_deficit = 0.0
         self._wake_meander_offset_m = 0.0
         self._wake_yaw_deflection_m = 0.0
+        # Atmospheric stability coupling (#99): α is farm-level time-varying,
+        # applied with per-turbine permanent offset from individuality.
+        self._effective_shear_alpha = 0.2 + self._individuality.get("wind_shear_exp_offset", 0.0)
+        self._atm_stability = 0.0
         self._sim_time = 0.0
         self._generated_power_kw = 0.0
         self._generator_speed = 0.0
@@ -322,13 +329,21 @@ class TurbinePhysicsModel:
              local_ti_multiplier: float = 1.0,
              wake_deficit: float = 0.0,
              wake_meander_offset_m: float = 0.0,
-             wake_yaw_deflection_m: float = 0.0) -> Dict[str, float]:
+             wake_yaw_deflection_m: float = 0.0,
+             wind_shear_exp_base: float = 0.2,
+             atm_stability: float = 0.0) -> Dict[str, float]:
         """Advance the turbine physics simulation by one timestep and return all SCADA tag values."""
         s = self.spec
         self._local_ti_multiplier = max(0.0, float(local_ti_multiplier))
         self._wake_deficit = max(0.0, min(0.70, float(wake_deficit)))
         self._wake_meander_offset_m = max(-80.0, min(80.0, float(wake_meander_offset_m)))
         self._wake_yaw_deflection_m = max(-80.0, min(80.0, float(wake_yaw_deflection_m)))
+        # Atmospheric stability: farm-level α base + per-turbine permanent offset (#99)
+        shear_offset = self._individuality.get("wind_shear_exp_offset", 0.0)
+        self._effective_shear_alpha = max(
+            0.04, min(0.35, float(wind_shear_exp_base) + float(shear_offset))
+        )
+        self._atm_stability = max(-1.0, min(1.0, float(atm_stability)))
         self._sim_time += dt
         self._update_grid_reference(dt, grid_frequency_ref, grid_voltage_ref)
         fault_physics = self._get_fault_physics()
@@ -382,7 +397,8 @@ class TurbinePhysicsModel:
 
         # Wind shear: 1P torque modulation from vertical wind profile (#71)
         # V(h) = V_hub × (h/h_hub)^α — blade sweeps different wind speeds
-        shear_exp = self._individuality.get("wind_shear_exp", 0.2)
+        # α is now farm-level time-varying (diurnal stability, #99) + per-turbine offset
+        shear_exp = self._effective_shear_alpha
         R = s.rotor_diameter / 2.0
         H = s.hub_height
         shear_torque_factor = 0.0
@@ -655,7 +671,7 @@ class TurbinePhysicsModel:
             is_starting=is_starting,
             is_emergency_stop=is_emergency_stop,
             rotor_azimuth_rad=self._rotor_azimuth,
-            wind_shear_exponent=self._individuality.get("wind_shear_exp", 0.2),
+            wind_shear_exponent=self._effective_shear_alpha,
             imbalance_force_kn=self._imbalance_force_kn,
             wind_veer_rate=self._individuality.get("wind_veer_rate", 0.10),
         )
@@ -715,6 +731,8 @@ class TurbinePhysicsModel:
             "WMET_WakeDef": round(self._wake_deficit * 100.0, 2),
             "WMET_WakeMndr": round(self._wake_meander_offset_m, 2),
             "WMET_WakeDefl": round(self._wake_yaw_deflection_m, 2),
+            "WMET_ShearAlpha": round(self._effective_shear_alpha, 4),
+            "WMET_AtmStab": round(self._atm_stability, 3),
             "WNAC_NacTmp": temps["nacelle"],
             "WNAC_NacCabTmp": temps["nac_cabinet"],
             "WNAC_VibMsNacXDir": round(vib_x, 3),
@@ -1058,6 +1076,10 @@ class TurbinePhysicsModel:
         self._wake_deficit = 0.0
         self._wake_meander_offset_m = 0.0
         self._wake_yaw_deflection_m = 0.0
+        # Atmospheric stability coupling (#99): α is farm-level time-varying,
+        # applied with per-turbine permanent offset from individuality.
+        self._effective_shear_alpha = 0.2 + self._individuality.get("wind_shear_exp_offset", 0.0)
+        self._atm_stability = 0.0
         self._sim_time = 0.0
         self._generated_power_kw = 0.0
         self._generator_speed = 0.0

--- a/wind_model.py
+++ b/wind_model.py
@@ -306,6 +306,80 @@ class WindEnvironmentModel:
 
         return base + diurnal + weather + self._rng.normal(0, 0.3)
 
+    # ─── Atmospheric stability (Monin-Obukhov diurnal coupling) ────────
+    #
+    # Realistic offshore/onshore boundary layers go through a strong diurnal
+    # stability cycle that drives both the vertical wind-shear exponent α and
+    # the turbulence intensity. We summarise it with a single continuous score
+    # s ∈ [−1, +1]:
+    #     −1 ⇒ strongly stable (nocturnal radiative cooling dominates)
+    #      0 ⇒ neutral
+    #     +1 ⇒ strongly unstable (daytime convective mixing)
+    #
+    # s = solar(t) · wind_damping(V) · cloud_damping(pressure)
+    #
+    #     solar(t)      = sin(π · (hour − 6)/12)       # +1 noon, 0 dawn/dusk, −1 midnight
+    #     wind_damping  = 1 / (1 + (V/8)²)              # high wind → mechanical mixing
+    #     cloud_damping = 1 − 0.5 · max(0, −pressure)   # low-pressure / fronts → clouds
+    #
+    # Manual override (profile / set_override) forces neutral to avoid
+    # surprising users who fix wind conditions during demos.
+
+    def get_atmospheric_stability(self, timestamp: datetime) -> float:
+        """Continuous atmospheric stability score in [-1, +1].
+
+        Negative = stable (night, clear sky, low wind → high α, low TI).
+        Positive = unstable (convective afternoon → low α, high TI).
+        Returns 0.0 (neutral) when any manual wind override is active.
+
+        Uses the weather model's current state (no side effects) so this can be
+        called multiple times per step without advancing RNG state.
+        """
+        if self._override_wind_speed is not None or self._active_profile is not None:
+            return 0.0
+
+        hour = timestamp.hour + timestamp.minute / 60.0
+        solar = math.sin((hour - 6.0) * math.pi / 12.0)
+
+        # Wind damping: use seasonal baseline × current weather multiplier
+        # (mirrors _get_auto_wind but without advancing weather.step).
+        month = timestamp.month
+        scale, shape = SEASONAL_PARAMS.get(month, (8.5, 2.1))
+        seasonal_mean = scale * math.gamma(1.0 + 1.0 / shape)
+        # pressure_state already reflects current synoptic state
+        weather_mult = 1.0 - self._weather._pressure_state * 0.4
+        v = max(0.5, seasonal_mean * weather_mult)
+        wind_damping = 1.0 / (1.0 + (v / 8.0) ** 2)
+
+        # Cloud damping: low pressure / fronts suppress both extremes
+        cloud_damping = 1.0 - 0.5 * max(0.0, -self._weather._pressure_state)
+
+        s = solar * wind_damping * cloud_damping
+        return max(-1.0, min(1.0, s))
+
+    def get_shear_exponent(self, timestamp: datetime,
+                           stability: Optional[float] = None) -> float:
+        """Farm-level wind shear exponent α (power-law V(h)=V_hub·(h/h_hub)^α).
+
+        α = clamp(0.14 − 0.10·s, 0.04, 0.30). Neutral value 0.14 follows
+        common offshore measurements (e.g. FINO1, Lillgrund).
+
+        Pass `stability` to avoid re-computing and re-mutating internal state.
+        """
+        s = stability if stability is not None else self.get_atmospheric_stability(timestamp)
+        return max(0.04, min(0.30, 0.14 - 0.10 * s))
+
+    def get_turbulence_multiplier(self, timestamp: datetime,
+                                  stability: Optional[float] = None) -> float:
+        """Multiplier applied on top of `turbulence_intensity` base (0.5 – 1.6).
+
+        At very stable night ≈ 0.5× base TI; at convective afternoon ≈ 1.5× base TI.
+
+        Pass `stability` to avoid re-computing and re-mutating internal state.
+        """
+        s = stability if stability is not None else self.get_atmospheric_stability(timestamp)
+        return max(0.5, min(1.6, 1.0 + 0.5 * s))
+
     def get_ambient_humidity(self, timestamp: datetime) -> float:
         """Relative humidity (%) with seasonal/diurnal/weather modulation.
 


### PR DESCRIPTION
## Summary

Implements atmospheric stability modeling that drives realistic diurnal variations in wind shear exponent (α) and turbulence intensity (TI). The system uses a continuous stability score derived from solar cycle, wind speed, and weather pressure to modulate both parameters, creating a physically consistent 24-hour boundary layer cycle.

## Key Changes

- **Wind model stability functions** (`wind_model.py`):
  - `get_atmospheric_stability(timestamp)` → continuous score s ∈ [−1, +1] based on solar(t) · wind_damping(V) · cloud_damping(pressure)
  - `get_shear_exponent(timestamp, stability)` → α = clamp(0.14 − 0.10·s, 0.04, 0.30)
  - `get_turbulence_multiplier(timestamp, stability)` → TI_mult = clamp(1.0 + 0.5·s, 0.5, 1.6)
  - Manual wind overrides force neutral (s = 0.0) to prevent surprising behavior during demos

- **Engine integration** (`simulator/engine.py`):
  - Compute `atm_stability` once per step and pass to both shear and TI getters to avoid redundant RNG mutations
  - Apply `ti_mult` to base turbulence intensity before feeding to both global and per-turbine turbulence generators
  - Pass `wind_shear_exp_base` and `atm_stability` to each turbine's step() call

- **Turbine physics** (`simulator/physics/turbine_physics.py`):
  - Renamed `wind_shear_exp` individuality key to `wind_shear_exp_offset` (semantic change: permanent offset rather than absolute value)
  - New state variables: `_effective_shear_alpha` (farm-level α + per-turbine offset), `_atm_stability`
  - Wind shear 1P torque modulation now uses time-varying `_effective_shear_alpha` instead of fixed individuality value
  - New SCADA outputs: `WMET_ShearAlpha` (α value), `WMET_AtmStab` (stability score)

- **SCADA registry** (`simulator/physics/scada_registry.py`):
  - Added `WMET_ShearAlpha` (REAL32, range 0.0–0.4)
  - Added `WMET_AtmStab` (REAL32, range −1.0–1.0)
  - Total SCADA tags increased from 97 to 99

## Physical Behavior

- **Nighttime** (stable): α rises to 0.18–0.22, TI drops to 50–80% of base
- **Daytime** (unstable): α drops to 0.08–0.11, TI rises to 120–140% of base
- **Strong wind** (V > 15 m/s): mechanical mixing damps stability extremes
- **Low pressure/fronts**: cloud cover suppresses both stable and unstable regimes
- Per-turbine permanent α offset (±0.04–0.06) stacks on top of farm-level time-varying α

## Impact

- Wind shear and turbulence now vary realistically throughout the day, affecting:
  - 1P blade torque modulation (#71)
  - Blade fatigue calculations (#72)
  - Wake expansion rates (#93)
  - Dynamic wake meandering baseline (#95)
- New SCADA tags enable 24-hour cycle observation and future fault diagnostics with diurnal baseline correction
- All downstream physics models (wake, turbulence, fatigue) now receive consistent time-varying parameters from a single unified stability model

https://claude.ai/code/session_0191Z9rJdSB7DBGcySJ2zSy3