### PR TITLE
feat: couple air density to ambient temperature and humidity (#101)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Current Position
 
-A working wind farm simulation platform with 99 SCADA tags, comprehensive physics models, and full API access for external data consumers.
+A working wind farm simulation platform with 100 SCADA tags, comprehensive physics models, and full API access for external data consumers.
 
 Platform includes:
 - backend REST + WebSocket APIs (40+ endpoints)
@@ -34,6 +34,7 @@ Primary focus (next improvements):
 - dynamic wake meandering — fixed: Larsen-DWM AR(1) lateral oscillation of wake centerline (σ_θ≈0.3·TI, τ≈25 s), downstream `WMET_WakeDef` now has realistic time variability — see #95
 - yaw-induced wake deflection (wake steering) — fixed: Bastankhah 2016 θ_c = 0.3·γ·(1−√(1−Ct·cos γ))/cos γ coupled to per-turbine yaw_error, new `WMET_WakeDefl` tag — see #97
 - atmospheric stability / diurnal shear-TI coupling — fixed: continuous score s=solar·wind_damping·cloud_damping drives α ∈ [0.04, 0.30] and TI multiplier ∈ [0.5, 1.6], new `WMET_ShearAlpha` / `WMET_AtmStab` tags — see #99
+- air density coupling — fixed: ρ(T, RH) from ideal gas law + Magnus moist-air correction, updated every step and fed into PowerCurveModel so P ∝ ρ·V³ and F ∝ ρ·V² vary with temperature and humidity; new `WMET_AirDensity` tag — see #101
 
 Secondary focus:
 - deployment hardening (JWT, Docker) — only when ready to share externally
@@ -77,6 +78,7 @@ Still pending or incomplete:
 - dynamic wake meandering — done: Larsen-DWM lateral AR(1) oscillation (σ_θ=0.3·TI, τ=25 s) applied to source wake centerline, new `WMET_WakeMndr` tag (#95)
 - yaw-induced wake deflection — done: Bastankhah 2016 skew angle coupled to per-turbine yaw_error, new `WMET_WakeDefl` tag (#97)
 - atmospheric stability / diurnal shear-TI coupling — done: Monin-Obukhov-simplified score s drives α ∈ [0.04, 0.30] and TI multiplier ∈ [0.5, 1.6], new `WMET_ShearAlpha` + `WMET_AtmStab` tags (#99)
+- air density coupling — done: moist-air ρ(T, RH) via ideal gas + Magnus, fed per-step to PowerCurveModel; aero power and thrust now vary ±10% with temperature/humidity; new `WMET_AirDensity` tag (#101)
 - SQLite vs time-series DB architecture decision — see #24
 - dependency security vulnerabilities (cryptography, pyjwt, etc.) — see #48
 - no automated test suite (pytest) — see #52

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Wind farm monitoring and digital twin platform with:
 - physics-based wind turbine simulation
-- 99 SCADA tags aligned to Bachmann Z72 definitions
+- 100 SCADA tags aligned to Bachmann Z72 definitions
 - fault injection and degradation scenarios
 - wind and grid condition control
 - Modbus TCP simulation
@@ -238,6 +238,7 @@ Historical storage currently grows continuously and does not yet have a cleanup 
 - dynamic wake meandering implemented (Larsen-DWM lateral AR(1) oscillation of wake centerline, σ_θ=0.3·TI, τ≈25 s, new `WMET_WakeMndr` SCADA tag) — see #95
 - yaw-induced wake deflection implemented (Bastankhah 2016 θ_c initial skew, per-source δ_y(x)=tan(θ_c)·x coupled to yaw_error, new `WMET_WakeDefl` SCADA tag; driven by yaw_misalignment fault and transient yaw lag) — see #97
 - atmospheric stability / diurnal shear-TI coupling implemented (Monin-Obukhov-simplified continuous stability score s ∈ [−1, +1] from solar time × wind mechanical mixing × cloud damping; drives wind shear exponent α ∈ [0.04, 0.30] and turbulence intensity multiplier ∈ [0.5, 1.6]; new `WMET_ShearAlpha` + `WMET_AtmStab` SCADA tags) — see #99
+- air density coupling implemented (moist-air ρ from ideal gas law + Buck/Magnus vapor correction; updated every step from ambient temp + humidity and injected into `PowerCurveModel.air_density` so aerodynamic power P ∝ ρ·V³ and thrust F ∝ ρ·V² both respond; ±10% swing between cold-winter and hot-humid days; new `WMET_AirDensity` SCADA tag) — see #101
 - full protection relay coordination not yet implemented
 - frontend RUL visualization pending (fatigue alarm thresholds, RUL estimation, and alarm event integration implemented — see #57)
 - dependency security vulnerabilities pending upgrade (see #48)

--- a/TODO.md
+++ b/TODO.md
@@ -57,6 +57,8 @@
 - [x] 97 SCADA tags total (was 96): +1 yaw-induced wake deflection tag (`WMET_WakeDefl`)
 - [x] Atmospheric stability / diurnal shear-TI coupling (continuous score s=solar·wind_damping·cloud_damping, α=0.14−0.10·s clamped [0.04, 0.30], TI_mult=1+0.5·s clamped [0.5, 1.6], strong-wind mechanical mixing, override-neutral, per-turbine α offset renamed) — see #99
 - [x] 99 SCADA tags total (was 97): +2 atmospheric stability tags (`WMET_ShearAlpha`, `WMET_AtmStab`)
+- [x] Air density coupling (ideal gas + Magnus moist-air correction; ρ fed per-step into PowerCurveModel; aero power P ∝ ρ·V³ and thrust F ∝ ρ·V² respond to ambient T / RH) — see #101
+- [x] 100 SCADA tags total (was 99): +1 air density tag (`WMET_AirDensity`)
 
 ### Backend
 - [x] FastAPI REST APIs
@@ -191,6 +193,7 @@ These parts are implemented, but still first-generation models:
 - [x] Dynamic wake meandering: Larsen-DWM AR(1) lateral oscillation applied per source (σ_θ=0.3·TI, τ=25 s), downstream `WMET_WakeDef` now has realistic time variability, new `WMET_WakeMndr` tag — see #95
 - [x] Yaw-induced wake deflection: Bastankhah 2016 initial skew θ_c=0.3·γ·(1−√(1−Ct·cos γ))/cos γ, δ_y(x)=tan(θ_c)·x coupled per-source; engine feeds per-turbine yaw_error back each step; new `WMET_WakeDefl` tag — see #97
 - [x] Atmospheric stability / diurnal shear-TI coupling: Monin-Obukhov-simplified continuous score s ∈ [−1, +1] from solar time × mechanical mixing × cloud damping; drives α (0.04–0.30) and TI multiplier (0.5–1.6); new `WMET_ShearAlpha` + `WMET_AtmStab` tags — see #99
+- [x] Air density coupling: ρ(T, RH) = P/(R_d·T) · (1 − 0.378·e/P) with Magnus vapor pressure; fed per-step into `PowerCurveModel.air_density`; power and thrust vary ±10% between cold-dry and hot-humid conditions; new `WMET_AirDensity` tag — see #101
 
 ### Deployment (low priority — lab-only use currently)
 - [ ] JWT authentication

--- a/docs/daily_report.md
+++ b/docs/daily_report.md
@@ -4,24 +4,26 @@
 
 ## 今日 Commit 摘要
 
-本次日報工作提交（分支 `claude/keen-hopper-ujMjS`）：
-- feat: atmospheric stability couples diurnal cycle to shear α and TI (#99)
+本次日報工作提交（分支 `claude/keen-hopper-V6hEC`）：
+
+- feat: couple air density to ambient temperature and humidity (#101)
 
 近 24 小時主幹 `main` 合併摘要：
+
+- [5ab4f32] Merge PR #100 — 大氣穩定度 α/TI 文件同步
+- [b275bdb] docs: update project docs and daily report for atmospheric stability (#99)
+- [cdaa177] feat: atmospheric stability couples diurnal cycle to shear α and TI (#99)
 - [d5b9adb] Merge PR #98 — 偏航引發尾流偏轉文件同步
 - [f96ec88] docs: update project docs and daily report for yaw-induced wake deflection (#97)
-- [8d520c8] feat: add yaw-induced wake deflection (Bastankhah 2016 wake steering) (#97)
-- [ea9ffae] Merge PR #96 — 動態尾流蜿蜒文件同步
-- [bf24c3a] docs: update project docs and daily report for dynamic wake meandering (#95)
 
 ## Issue 狀態
 
 | 動作 | Issue # | 標題 | 說明 |
 |------|---------|------|------|
-| 建立 | #99 | 大氣穩定度 Monin-Obukhov — 日週期風切指數 α 與亂流強度 TI 耦合 | 今日建立並實作 |
-| 實作 | #99 | 大氣穩定度日週期耦合 | 新增 `WMET_ShearAlpha` + `WMET_AtmStab`，5 項自測全過 |
-| 保持 | #97 | 偏航引發尾流偏轉 | 昨日已實作並合併 main |
-| 保持 | #67 | 完整保護繼電器協調 LVRT/OVRT | 電壓-時間保護曲線 |
+| 關閉 | #97 | 偏航引發尾流偏轉 | 已於 PR #98 合併 main，補上完成註解並 close |
+| 建立 | #101 | 空氣密度 ρ(T, RH) 動態耦合 | 今日建立並實作 |
+| 實作 | #101 | 空氣密度耦合 | 新增 `WMET_AirDensity`，4 項自測全過 |
+| 保持 | #67 | 完整保護繼電器協調 LVRT/OVRT | 電壓-時間保護曲線待做 |
 | 保持 | #58 | 頻譜振動警報閾值與邊帶分析 | 頻帶警報曲線仍待做 |
 | 保持 | #57 | 疲勞警報閾值與 RUL 估算 | 後端完成，前端 RUL 視覺化待做 |
 | 保持 | #52 | 缺少自動化測試套件 | 仍無 pytest |
@@ -32,14 +34,13 @@
 | 保持 | #26 | 部署強化 | Docker 已完成，JWT/RBAC 待做 |
 | 保持 | #24 | 歷史資料儲存架構 | 架構決策待定 |
 
-本日建立 1 個 issue（#99），符合「每次最多 3 個新 issue」規則。
+本日建立 1 個 issue（#101）、關閉 1 個（#97），符合「每次最多 3 個新 issue」規則。
 
 ## Open Issues 總覽
 
 | # | 標題 | Labels | 建立日期 | 備註 |
 |---|------|--------|----------|------|
-| #99 | 大氣穩定度 Monin-Obukhov 日週期耦合 | enhancement, physics, auto-detected | 2026-04-22 | 已實作 |
-| #97 | 偏航引發尾流偏轉 — Bastankhah 2016 | enhancement, physics, auto-detected | 2026-04-21 | 已合併 main |
+| #101 | 空氣密度 ρ(T, RH) 動態耦合 | enhancement, physics, auto-detected | 2026-04-22 | 已實作 |
 | #67 | 完整保護繼電器協調 LVRT/OVRT | enhancement, physics, auto-detected | 2026-04-16 | 電壓-時間曲線 |
 | #58 | 頻譜振動警報閾值與邊帶分析 | enhancement, physics, auto-detected | 2026-04-15 | 頻帶警報曲線待做 |
 | #57 | 疲勞警報閾值與 RUL 估算 | enhancement, physics, auto-detected | 2026-04-15 | 前端 RUL 待做 |
@@ -56,15 +57,15 @@
 | 模組 | 最後修改 | TODO 數 | 測試 | 備註 |
 |------|----------|---------|------|------|
 | `server/` | 2026-04-17 | 0 | 無測試套件 | 無變更 |
-| `simulator/` | 2026-04-22 | 0 | 無測試套件 | `engine.py` 新增穩定度/α/TI_mult 計算與傳遞 |
-| `simulator/physics/` | 2026-04-22 | 0 | 無測試套件 | `turbine_physics` 接收 `wind_shear_exp_base`/`atm_stability` kwargs、`scada_registry` 新增 `WMET_ShearAlpha`/`WMET_AtmStab` |
-| `wind_model.py`（根目錄） | 2026-04-22 | 0 | 無測試套件 | 新增 `get_atmospheric_stability`/`get_shear_exponent`/`get_turbulence_multiplier` |
+| `simulator/` | 2026-04-22 | 0 | 無測試套件 | `engine.py` 每步計算 `air_density` 並傳遞 |
+| `simulator/physics/` | 2026-04-22 | 0 | 無測試套件 | `turbine_physics` 接收 `air_density` kwarg 並更新 `PowerCurveModel.air_density`；`scada_registry` 新增 `WMET_AirDensity` |
+| `wind_model.py`（根目錄） | 2026-04-22 | 0 | 無測試套件 | 新增 `get_air_density(ts, temp?, rh?)` |
 | `frontend/` | 2026-04-17 | 0 | 無測試套件 | 無變更 |
 | 根目錄原型 | 2026-04-12 | 0 | — | 早期原型檔案 |
 
 ## API Endpoints
 
-共 58 個路由（57 HTTP + 1 WebSocket）。無新增路由。詳見 README.md「Core APIs」章節。
+共 62 個路由（61 HTTP + 1 WebSocket）。本日無新增路由。詳見 README.md「Core APIs」章節。
 
 待同步：`/api/farms`（10 個路由）仍未完整同步至 README 的 Core APIs 章節。
 
@@ -72,120 +73,116 @@
 
 - Lint 錯誤：115（核心模組 `server/` + `simulator/` 維持 0 錯誤）
 - `ruff check simulator/ server/ wind_model.py` — All checks passed ✓
-- `python -m py_compile simulator/physics/{turbine_physics,scada_registry}.py simulator/engine.py wind_model.py` — 4 個修改檔案全部通過
+- `python -m py_compile simulator/engine.py simulator/physics/turbine_physics.py simulator/physics/scada_registry.py wind_model.py` — 4 個修改檔案全部通過
 - Broken imports：0（核心模組全部通過）
 - 語法錯誤：0
 - 測試套件：未建立（無 pytest）— 追蹤 issue #52
 - 安全漏洞：17 個（5 個套件），詳見 #48
 - TODO/FIXME/HACK：0 個（核心模組）
-- SCADA 標籤：**99 個**（+2：`WMET_ShearAlpha`、`WMET_AtmStab`）
+- SCADA 標籤：**100 個**（+1：`WMET_AirDensity`）
 
 ## 今日新增功能
 
-### 大氣穩定度日週期耦合 Atmospheric Stability Coupling（#99）
+### 空氣密度 ρ(T, RH) 動態耦合（#101）
 
-**物理原理**
+**問題與物理原理**
 
-離岸/陸上邊界層有強烈的**日週期穩定度循環**，這是所有長期量測資料共同觀察到的現象：
+`simulator/physics/power_curve.py` 與 `turbine_physics.py` 長期以 `air_density = 1.225 kg/m³` 常數計算氣動功率與推力：
 
-| 時段 | 穩定度 | 典型 α | 典型 TI | 物理成因 |
-|------|-------|-------|---------|----------|
-| 深夜/清晨 | 強穩定 | 0.25–0.35 | 0.05–0.08 | 地表輻射冷卻 → 近地層溫度反轉 → 抑制垂直混合 |
-| 日出/日落 | 中性 | 0.14 | 0.10 | 熱平衡過渡期 |
-| 正午/午後 | 強不穩定 | 0.06–0.12 | 0.12–0.18 | 太陽加熱地表 → 熱浮力 → 激烈垂直混合 |
-| 強風或陰天 | 機械/中性 | 趨近 0.14 | 趨近 0.10 | 機械混合或雲層削弱日射效應 |
+- `P_aero = Cp × 0.5 × ρ × A × V³` — P 對 ρ 線性
+- `F_thrust = 0.5 × ρ × A × Ct × V²` — F 對 ρ 線性
 
-使用連續穩定度分數 `s ∈ [−1, +1]`：
+但實際大氣中 ρ 會依**溫度**與**濕度**顯著變動：
+
+| 典型條件 | ρ (kg/m³) | 相對 1.225 | 物理意義 |
+|----------|-----------|------------|----------|
+| 標準 ISA（15 °C, 0% RH） | 1.2250 | ±0.0% | 基準 |
+| 熱帶雨季（32 °C, 95% RH） | 1.1372 | −7.2% | 高溫 + 水氣稀釋 |
+| 沙漠白天（40 °C, 40% RH） | 1.1147 | −9.0% | 高溫主導 |
+| 溫帶夜間（0 °C, 50% RH） | 1.2908 | +5.4% | 冷空氣緻密 |
+| 寒冷冬夜（−10 °C, 50% RH） | 1.3406 | +9.4% | 空氣最緻密 |
+| 極冷乾燥（−20 °C, 30% RH） | 1.3500 | +10.2% | clamp 上限 |
+
+兩極差異達 15%，代表**冷冬空氣可比熱夏空氣多產生約 10–12% 的功率**，這是真實風場不可忽略的季節/日週期特徵，先前完全未被模擬。
+
+**公式**
+
+理想氣體定律 + Buck/Magnus 飽和蒸氣修正：
+
 ```
-s = solar(t) × wind_damping(V) × cloud_damping(pressure)
-
-solar(t)       = sin(π · (hour − 6)/12)               # +1 正午、0 晨昏、−1 午夜
-wind_damping   = 1 / (1 + (V/8)²)                      # 強風機械混合壓低 |s|
-cloud_damping  = 1 − 0.5 · max(0, −pressure_state)     # 低壓鋒面雲層削弱
+ρ_dry    = P / (R_d × T_K)                      R_d = 287.058 J/(kg·K)
+e_s(T_C) = 611.2 · exp(17.67 · T_C / (T_C + 243.5))    # 飽和蒸氣壓 (Pa)
+e        = (RH/100) × e_s                        # 實際蒸氣壓
+ρ_moist  = ρ_dry × (1 − 0.378 · e / P)           # 水蒸氣較輕，總體密度下降
 ```
 
-對應風切與 TI：
-```
-α(s)      = clamp(0.14 − 0.10·s, 0.04, 0.30)
-TI_mult(s)= clamp(1.0 + 0.5·s,   0.5,  1.6)
-```
+海平面 `P = 101325 Pa`，結果 clamp 至 [0.95, 1.35]。
 
 **實作方式**
 
 1. `wind_model.py::WindEnvironmentModel`：
-   - `get_atmospheric_stability(timestamp)` → 連續分數 [-1, +1]
-     - 手動 override 時回 0.0（中性）
-     - 無副作用：重構為使用 `_weather._pressure_state` 直接讀取，不再呼叫 `_get_auto_wind`，每步可多次呼叫而不改變 RNG 狀態
-   - `get_shear_exponent(timestamp, stability=None)` → α
-   - `get_turbulence_multiplier(timestamp, stability=None)` → TI 倍率
-   - 新的 `stability` 可選參數允許呼叫端預先計算 s 後共享，避免重複計算
+   - `get_air_density(timestamp, ambient_temp=None, humidity=None) -> float`
+   - `ambient_temp` / `humidity` 可選 — 若 engine 已計算好就直接傳入，避免再度呼叫 `_weather._pressure_state` 等並污染 RNG（同 #99 設計）
 
-2. `simulator/engine.py`：
-   - 每步計算 `atm_stability` 一次，然後傳入 `get_shear_exponent(stability=s)` 與 `get_turbulence_multiplier(stability=s)` 避免重複
-   - `effective_ti = wind_model.turbulence_intensity × TI_mult`
-   - 同時餵給 `_turbulence_gen.step(ti=effective_ti)` 與 `_per_turbine_wind.step(..., effective_ti, ...)`
-   - 每台風機 `turbine.step(..., wind_shear_exp_base=shear_alpha, atm_stability=atm_stability)`
+2. `simulator/engine.py`：每步共用一組 `ambient_temp`、`ambient_humidity`，新增
+
+   ```python
+   air_density = self.wind_model.get_air_density(
+       sim_time, ambient_temp=ambient_temp, humidity=ambient_humidity
+   )
+   ```
+
+   傳入每台 `turbine.step(..., air_density=air_density)`。**全場共享同一 ρ**（物理事實：同一氣團）。
 
 3. `simulator/physics/turbine_physics.py`：
-   - `step()` 新增 `wind_shear_exp_base: float = 0.2` 與 `atm_stability: float = 0.0` kwargs
-   - `_individuality` 的 `wind_shear_exp` 鍵**重新命名**為 `wind_shear_exp_offset`，語意從「絕對 α」改為「永久偏置」（±0.04~+0.06）
-   - `_effective_shear_alpha = clamp(wind_shear_exp_base + offset, 0.04, 0.35)`，用於 1P 風切扭矩調變與疲勞計算
-   - `__init__` 與 `reset()` 初始化新狀態 `_effective_shear_alpha`、`_atm_stability`
-   - SCADA 輸出新增 `"WMET_ShearAlpha"` 與 `"WMET_AtmStab"`
+   - `step()` 新增 `air_density: float = 1.225` kwarg
+   - `self._air_density = clamp(...)`；**最關鍵：`self.power_curve.air_density = self._air_density`**，使下一次 `get_power_cp` 內部即使用最新的 ρ
+   - 新增 SCADA 輸出 `"WMET_AirDensity"`（`round(ρ, 4)`）
+   - `__init__` 與 `reset()` 初始化 `self._air_density = self.spec.air_density`
 
 4. `simulator/physics/scada_registry.py`：
-   - 新增 `ScadaTag("WMET_ShearAlpha", ..., "REAL32", "-", ..., 0.0, 0.4)`
-   - 新增 `ScadaTag("WMET_AtmStab", ..., "REAL32", "-", ..., -1.0, 1.0)`
-   - **SCADA 總數從 97 增為 99**
+   - 新增 `ScadaTag("WMET_AirDensity", ..., "REAL32", "kg/m3", ..., 0.95, 1.35)`
+   - **SCADA 總數從 99 增為 100**
 
 **物理效應（自測驗證）**
 
-`WindEnvironmentModel(seed=42)`，2026-04-22：
-
-| 時段 | 預期 s | 實測 s | α | TI_mult | 結果 |
-|------|--------|--------|---|---------|------|
-| 02:00（夜） | s ≤ −0.35 | **−0.459** | 0.186 | 0.770 | ✓ |
-| 06:00（晨） | s ≈ 0 | **+0.000** | 0.140 | 1.000 | ✓ |
-| 13:00（午） | s ≥ 0.35 | **+0.512** | 0.089 | 1.256 | ✓ |
-| 18:00（昏） | s ≈ 0 | **+0.000** | 0.140 | 1.000 | ✓ |
-| 21:00（夜） | 負 | **−0.422** | 0.182 | 0.789 | ✓ |
-| 手動 override 8 m/s@noon | s=0 強制中性 | **0.000** | 0.140 | 1.000 | ✓ |
-| V=20 m/s 機械混合 | wind_damping ≤ 0.15 | **0.138** | — | — | ✓ |
-
-Engine 端整合：
-- 3 台風機在同一步同時收到共用的 `atm_stability`（已追溯至 turbine.step 的 kwargs，完全一致）
-- per-turbine α 結構性差異保留（spread 0.07–0.12，由 `wind_shear_exp_offset` 驅動）
-- SCADA 輸出 `WMET_AtmStab`/`WMET_ShearAlpha` 在前後兩步之間平滑變化（無瞬跳）
-
-**影響範圍**
-
-- **風切 α** 現在依時間變動，而不是固定 0.2：夜間 α 升到 0.18–0.22，白天降至 0.08–0.11。這會直接反映在 #71 的 1P 葉片扭矩調變和 #72 的葉片疲勞計算上
-- **TI_mult** 直接乘上基準 `turbulence_intensity`：夜間亂流下降到 60–80%，白天放大到 120–140%。會影響：
-  - #95 動態尾流蜿蜒（σ_θ=0.3·TI 之基線變動）
-  - #93 Bastankhah 尾流擴展率（k*=0.38·TI+0.004）
-  - 全場每步的湍流分量（`_turbulence_gen`）與每台風機的永久湍流（`_per_turbine_wind._turb_gens`）
-- 新 SCADA 標籤 `WMET_ShearAlpha`、`WMET_AtmStab` 可於歷史圖表觀察 24 小時週期，或用於後續故障診斷的「日週期基線校正」
-- 與 #89（濕度）、#91（局部亂流）、#93/#95/#97（尾流）共用 `WindEnvironmentModel` 的 `_weather._pressure_state` 軌跡，所以天氣鋒面會**同時**影響風切/TI、濕度、尾流 — 系統性自洽
+| 測試 | 預期 | 實測 | 結果 |
+|------|------|------|------|
+| 15 °C / 0% RH（ISA） | 1.225 ± 0.005 | 1.2250 | ✓ |
+| 25 °C / 65% RH（日常） | 約 1.17 | 1.1748 | ✓ |
+| 0 °C / 50% RH | ≈ 1.29 | 1.2908 | ✓ |
+| −10 °C / 50% RH | ≈ 1.34 | 1.3406 | ✓ |
+| −20 °C / 30% RH | ≥ 1.35（hit clamp） | 1.3500 | ✓ |
+| 32 °C / 95% RH（熱帶） | 約 1.14 | 1.1372 | ✓ |
+| 40 °C / 40% RH（沙漠） | 約 1.11 | 1.1147 | ✓ |
+| 冷/熱功率比（0°C 50% vs 30°C 80%） | 1.10–1.12 | 1.123 | ✓ |
 
 **為何這是物理「因」而非輸出偏移**
 
-- 根源於時間（日週期）與環境（風速、雲量）的真實物理驅動
-- 經由 α、TI 兩個**已存在**的物理參數路徑傳遞到所有下游模型（風切葉片負載、尾流擴展、湍流產生器）
-- 每台風機仍有**永久 α 偏置**（`wind_shear_exp_offset`）疊加在時變基線之上：持續差異 + 時間過渡雙重觀察
-- 手動 override 自動切回中性，避免 demo 時穩定度「莫名其妙變動」
+- 直接源於氣體狀態方程與水蒸氣的摩爾質量差（M_v=18 vs M_a=29），為物理定律
+- ρ 變化經由 `PowerCurveModel` 內**原本就存在**的 `air_density` 代入點傳遞；P、F、Ct 推力估算、疲勞 DEL 全路徑自動耦合，**無需**直接修改功率輸出 tag
+- 全場共享同一 ρ 反映「同一氣團」的物理事實；per-turbine 差異則留給 `wind_sensor_scale` 等既有個體路徑
+- 手動 override ambient_temp 會產生穩定的中性濕度，ρ 仍會依當時溫度自然計算，不需額外分支邏輯
+
+**與其他模型的耦合**
+
+- **#89（環境濕度）**：濕度路徑共用；本 issue 走**進氣密度**，#89 走**散熱效率**，兩者互為補充而非重複
+- **#99（大氣穩定度）**：夜間穩定度高 → 溫度低 → ρ 升高 → 功率升高；日間對流 → 溫度高 → ρ 降低。日週期協同加強
+- **#71 / #72（風切、葉片不平衡）**：塔基推力 F 亦 ∝ ρ，塔基疲勞 DEL 會在季節/日週期上同步振動
+- **#93 / #95 / #97（尾流）**：尾流 Ct 係經驗公式未依 ρ 縮放，未來若要做「尾流推力與風場動能耗散」一致性校驗，ρ 會是必要輸入
 
 ## 建議行動
 
-1. **長時段資料品質驗證**：以 `examples/data_quality_analysis.py` 跑 24 h 自動模式（time_scale=60），觀察：
-   - `WMET_AtmStab` 是否呈現日週期正弦波
-   - `WMET_ShearAlpha` 夜間是否 0.18–0.22、白天是否 0.08–0.11
-   - 塔架疲勞損傷率是否夜間升高（高剪切 → 1P 負載放大）
-2. **前端視覺化**：Dashboard 可新增穩定度熱圖或時間軸，標註白天/夜間區段
+1. **長時段資料品質驗證**：以 `examples/data_quality_analysis.py` 跑 **7 天自動模式**（time_scale=144），觀察：
+   - `WMET_AirDensity` 日週期（清晨高、午後低）
+   - 冷暖季基準差異（ρ 在冬夏月之間應有 ~5% 差距）
+   - 相同風速時段的平均功率是否呈現 ρ-相關變動
+2. **前端視覺化**：Dashboard 可於 weather widget 加上即時 ρ 與相對 1.225 的差異百分比（冷空氣 +5% 的提示能直觀表達物理因）
 3. **實作 #58 頻譜警報曲線**：前端顯示各頻帶警報閾值
 4. **實作 #57 前端 RUL 視覺化**：後端已就緒
-5. **建立 pytest 測試套件（#52）**：α(s)、TI_mult(s)、override 中性化為理想首批單元測試案例
+5. **建立 pytest 測試套件（#52）**：ρ(T, RH)、α(s)、TI_mult(s)、override 中性化為理想首批單元測試
 6. **未來擴充**：
-   - 海氣溫差（Sea-Air ΔT）驅動穩定度（目前用 `_pressure_state` 作代理）
-   - Low-level Jet（LLJ）夜間風速剖面
-   - 風切與葉片飛彈負載的非對稱性（轉子上下半部 V² 差異）
+   - 大氣壓 P 的日週期/天氣鋒面依賴（目前固定 P=101325 Pa；實測可偏 ±2%）
+   - 高海拔風場的海拔修正（離岸通常 ~0 m，陸上山坡風場可偏 5–10%）
+   - 冷空氣對葉片結冰閾值的聯合觸發（`blade_icing` 故障可視 ρ 與 T 同時判斷）
 7. **同步 `/api/farms` 10 個路由至 README.md**：仍未完成

--- a/docs/physics_model_status.md
+++ b/docs/physics_model_status.md
@@ -1,6 +1,6 @@
 # Physics Model Status
 
-Last updated: 2026-04-22 (atmospheric stability / diurnal shear-TI coupling)
+Last updated: 2026-04-22 (air density coupling)
 
 This document tracks the current completion status of the wind turbine physics models.
 It is intended to be the single reference for:
@@ -366,6 +366,10 @@ Newly implemented:
   - per-turbine permanent α offset (±0.04–0.06) renamed to `wind_shear_exp_offset` and stacks on farm-level α
   - New SCADA tags: `WMET_ShearAlpha` (α), `WMET_AtmStab` (s)
 
+Newly implemented:
+- Air density coupling (#101): moist-air ρ from ideal gas law + Buck/Magnus vapor correction,
+  `ρ = P/(R_d·T_K) · (1 − 0.378·e/P)`, P=101325 Pa, R_d=287.058. `WindEnvironmentModel.get_air_density(ts, temp?, rh?)` shares the temp/humidity already computed for stability, so no extra RNG mutation per step. Engine passes ρ to every turbine (same airmass), and `turbine_physics.step()` writes it into `PowerCurveModel.air_density` each tick so aero power `P = Cp·0.5·ρ·A·V³` and thrust `F = 0.5·ρ·A·Ct·V²` both respond automatically. Verified: 15 °C / 0% RH → 1.2250 (ISA), −10 °C / 50% RH → 1.3406 (+9.4%), 32 °C / 95% RH → 1.1372 (−7.2%), cold/hot power ratio 1.123. Clamp [0.95, 1.35]. New SCADA tag `WMET_AirDensity`.
+
 Still missing:
 - curled-wake model for skewed inflow (yaw-deflection is handled via Bastankhah linear form; curled-wake adds counter-rotating vortex pair detail)
 
@@ -514,7 +518,7 @@ Implemented:
 - spectral vibration bands with fault-specific signatures
 - vibration alarm thresholds with ISO 10816-inspired zones
 - fatigue / load modeling (tower + blade moments, DEL, Miner's damage, alarm thresholds, RUL, tower SDOF dynamics)
-- 99 SCADA tags (electrical + vibration + structural load + alarm/RUL + bearing diagnostics + gear mesh sidebands + crest/kurtosis alarms + gearbox oil temp + tooth wear + outside humidity + local TI multiplier + Bastankhah wake deficit + wake meander offset + yaw-induced wake deflection + atmospheric stability + shear α)
+- 100 SCADA tags (electrical + vibration + structural load + alarm/RUL + bearing diagnostics + gear mesh sidebands + crest/kurtosis alarms + gearbox oil temp + tooth wear + outside humidity + local TI multiplier + Bastankhah wake deficit + wake meander offset + yaw-induced wake deflection + atmospheric stability + shear α + air density)
 
 ### Still Weak
 - spectral alarm threshold curves — see #58 (crest factor/kurtosis anomaly alarms now completed)
@@ -546,4 +550,5 @@ Implemented:
 14. ~~dynamic wake meandering (Larsen DWM)~~ → done (#95, AR(1) lateral wake centerline with σ_θ=0.3·TI, τ=25 s)
 15. ~~yaw-induced wake deflection / wake steering (Bastankhah 2016)~~ → done (#97, θ_c initial skew + δ_y(x)=tan(θ_c)·x, `WMET_WakeDefl`)
 16. ~~atmospheric stability / diurnal shear-TI coupling~~ → done (#99, s ∈ [−1, +1] → α, TI_mult, `WMET_ShearAlpha`, `WMET_AtmStab`)
-17. deployment hardening (JWT auth, RBAC, Docker Compose)
+17. ~~air density coupling~~ → done (#101, moist-air ρ(T,RH) → PowerCurveModel per step, `WMET_AirDensity`)
+18. deployment hardening (JWT auth, RBAC, Docker Compose)

--- a/simulator/engine.py
+++ b/simulator/engine.py
@@ -111,6 +111,12 @@ class WindFarmSimulator:
         ti_mult = self.wind_model.get_turbulence_multiplier(sim_time, stability=atm_stability)
         effective_ti = max(0.0, self.wind_model.turbulence_intensity * ti_mult)
 
+        # Air density ρ(T, RH) from ideal gas law + Magnus vapor correction (#101).
+        # Shared by all turbines (physical fact: same airmass across the farm).
+        air_density = self.wind_model.get_air_density(
+            sim_time, ambient_temp=ambient_temp, humidity=ambient_humidity
+        )
+
         turb_component = self._turbulence_gen.step(
             base_wind, effective_ti, time_step
         )
@@ -170,6 +176,7 @@ class WindFarmSimulator:
                 wake_yaw_deflection_m=wake_yaw_defl_m,
                 wind_shear_exp_base=shear_alpha,
                 atm_stability=atm_stability,
+                air_density=air_density,
             )
 
             # Capture yaw_error (deg) for this step; fed back next step to drive

--- a/simulator/physics/scada_registry.py
+++ b/simulator/physics/scada_registry.py
@@ -178,6 +178,10 @@ _TAGS: List[ScadaTag] = [
              "WMET", "REAL32", "-", "Atmospheric Stability Score (-1 stable..+1 unstable)",
              "大氣穩定度分數(-1 穩定..+1 不穩定)",
              -1.0, 1.0),
+    ScadaTag("WMET_AirDensity", "WMET.Z72PLC__UI_Loc_WMET_Analogue_AirDensity",
+             "WMET", "REAL32", "kg/m3", "Moist Air Density (ideal gas + Magnus)",
+             "濕空氣密度(理想氣體+Magnus 修正)",
+             0.95, 1.35),
 
     # ══════════════════════════════════════════════════════════════════════
     # WNAC — Nacelle

--- a/simulator/physics/turbine_physics.py
+++ b/simulator/physics/turbine_physics.py
@@ -258,6 +258,8 @@ class TurbinePhysicsModel:
         # applied with per-turbine permanent offset from individuality.
         self._effective_shear_alpha = 0.2 + self._individuality.get("wind_shear_exp_offset", 0.0)
         self._atm_stability = 0.0
+        # Air density ρ(T, RH) — updated per step from ambient temp + humidity (#101)
+        self._air_density = self.spec.air_density
         self._sim_time = 0.0
         self._generated_power_kw = 0.0
         self._generator_speed = 0.0
@@ -331,7 +333,8 @@ class TurbinePhysicsModel:
              wake_meander_offset_m: float = 0.0,
              wake_yaw_deflection_m: float = 0.0,
              wind_shear_exp_base: float = 0.2,
-             atm_stability: float = 0.0) -> Dict[str, float]:
+             atm_stability: float = 0.0,
+             air_density: float = 1.225) -> Dict[str, float]:
         """Advance the turbine physics simulation by one timestep and return all SCADA tag values."""
         s = self.spec
         self._local_ti_multiplier = max(0.0, float(local_ti_multiplier))
@@ -344,6 +347,9 @@ class TurbinePhysicsModel:
             0.04, min(0.35, float(wind_shear_exp_base) + float(shear_offset))
         )
         self._atm_stability = max(-1.0, min(1.0, float(atm_stability)))
+        # Air density ρ(T, RH) drives aero power (P ∝ ρ·V³) and thrust (F ∝ ρ·V²) (#101)
+        self._air_density = max(0.95, min(1.35, float(air_density)))
+        self.power_curve.air_density = self._air_density
         self._sim_time += dt
         self._update_grid_reference(dt, grid_frequency_ref, grid_voltage_ref)
         fault_physics = self._get_fault_physics()
@@ -733,6 +739,7 @@ class TurbinePhysicsModel:
             "WMET_WakeDefl": round(self._wake_yaw_deflection_m, 2),
             "WMET_ShearAlpha": round(self._effective_shear_alpha, 4),
             "WMET_AtmStab": round(self._atm_stability, 3),
+            "WMET_AirDensity": round(self._air_density, 4),
             "WNAC_NacTmp": temps["nacelle"],
             "WNAC_NacCabTmp": temps["nac_cabinet"],
             "WNAC_VibMsNacXDir": round(vib_x, 3),
@@ -1080,6 +1087,8 @@ class TurbinePhysicsModel:
         # applied with per-turbine permanent offset from individuality.
         self._effective_shear_alpha = 0.2 + self._individuality.get("wind_shear_exp_offset", 0.0)
         self._atm_stability = 0.0
+        # Air density ρ(T, RH) — updated per step from ambient temp + humidity (#101)
+        self._air_density = self.spec.air_density
         self._sim_time = 0.0
         self._generated_power_kw = 0.0
         self._generator_speed = 0.0

--- a/wind_model.py
+++ b/wind_model.py
@@ -409,3 +409,25 @@ class WindEnvironmentModel:
 
         rh = base + diurnal + weather + self._rng.normal(0, 0.8)
         return max(15.0, min(100.0, rh))
+
+    def get_air_density(self, timestamp: datetime,
+                        ambient_temp: Optional[float] = None,
+                        humidity: Optional[float] = None) -> float:
+        """Moist air density ρ (kg/m³) from ideal gas law + Magnus correction.
+
+        ρ_dry   = P / (R_d · T_K)                R_d = 287.058 J/(kg·K)
+        e_s(T)  = 611.2 · exp(17.67·T_C/(T_C+243.5))   (Pa, Buck/Magnus)
+        ρ_moist = ρ_dry · (1 − 0.378·e/P)        e = (RH/100)·e_s
+
+        Typical range: ~1.15 (32 °C / 95% RH) to ~1.34 (−10 °C / 50% RH).
+        Pass `ambient_temp` / `humidity` to avoid re-computing those upstream.
+        """
+        t_c = ambient_temp if ambient_temp is not None else self.get_ambient_temp(timestamp)
+        rh = humidity if humidity is not None else self.get_ambient_humidity(timestamp)
+        t_k = t_c + 273.15
+        e_s = 611.2 * math.exp(17.67 * t_c / (t_c + 243.5))
+        e = max(0.0, min(1.0, rh / 100.0)) * e_s
+        p_atm = 101325.0
+        rho_dry = p_atm / (287.058 * t_k)
+        rho = rho_dry * (1.0 - 0.378 * e / p_atm)
+        return max(0.95, min(1.35, rho))


### PR DESCRIPTION
## Summary

Implement dynamic air density (ρ) coupling based on ambient temperature and relative humidity using the ideal gas law with Magnus vapor pressure correction. Air density now varies realistically across the simulation (±10% range), directly affecting aerodynamic power and thrust calculations.

## Key Changes

- **`wind_model.py`**: Added `get_air_density(timestamp, ambient_temp=None, humidity=None)` method that computes moist air density using the formula:
  ```
  ρ_dry = P / (R_d · T_K)
  e_s(T) = 611.2 · exp(17.67·T_C/(T_C+243.5))
  ρ_moist = ρ_dry · (1 − 0.378·e/P)
  ```
  Results are clamped to [0.95, 1.35] kg/m³. Optional temp/humidity parameters allow reusing values already computed upstream to avoid RNG pollution.

- **`simulator/engine.py`**: Each simulation step now computes `air_density` once and passes it to all turbines (reflecting the physical fact that all turbines share the same airmass). Computation reuses the ambient temperature and humidity already fetched for atmospheric stability.

- **`simulator/physics/turbine_physics.py`**: 
  - Added `air_density` kwarg to `step()` method
  - Store `_air_density` state and clamp to valid range
  - **Critical**: Update `self.power_curve.air_density` each step so that aerodynamic power (`P = Cp·0.5·ρ·A·V³`) and thrust (`F = 0.5·ρ·A·Ct·V²`) automatically respond to density changes
  - Added new SCADA output tag `WMET_AirDensity`

- **`simulator/physics/scada_registry.py`**: Registered new `WMET_AirDensity` tag (REAL32, kg/m³, range 0.95–1.35)

- **Documentation**: Updated `docs/daily_report.md`, `docs/physics_model_status.md`, `README.md`, `CLAUDE.md`, and `TODO.md` to reflect the new feature and increased SCADA tag count from 99 to 100.

## Physical Justification

Real-world air density varies significantly with temperature and humidity:
- **Cold winter night** (−10 °C, 50% RH): ρ ≈ 1.34 kg/m³ (+9.4%)
- **Hot tropical day** (32 °C, 95% RH): ρ ≈ 1.14 kg/m³ (−7.2%)
- **Standard ISA** (15 °C, 0% RH): ρ = 1.225 kg/m³ (baseline)

This 15% swing means cold-season air can produce ~10–12% more power than hot-season air at identical wind speeds—a seasonal effect previously unmodeled. The implementation couples naturally with #99 (atmospheric stability): stable nights are cold (high ρ) while unstable days are warm (low ρ), creating coherent diurnal cycles.

## Testing

Verified against standard atmospheric conditions:
- ISA (15 °C, 0% RH) → 1.2250 ✓
- Cold (−10 °C, 50% RH) → 1.3406 ✓
- Tropical (32 °C, 95% RH) → 1.1372 ✓
- Cold/hot power ratio → 1.123 ✓

https://claude.ai/code/session_018DbC8UaxL8ghdAF1qXm1ye